### PR TITLE
fix italian translation for passengerseat_window

### DIFF
--- a/custom_components/toyota/translations/it.json
+++ b/custom_components/toyota/translations/it.json
@@ -89,7 +89,7 @@
         "name": "Finestrino del conducente"
       },
       "passengerseat_window": {
-        "name": "Finsetrino del passeggero"
+        "name": "Finestrino del passeggero"
       },
       "leftrearseat_window": {
         "name": "Finestrino posteriore sinistro"


### PR DESCRIPTION
Fix italian translation for `passengerseat_window` as mentioned in #34 