### PR TITLE
Avoid blocking calls

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - name: "⤵️ Check out code from GitHub"
         uses: "actions/checkout@v5"

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -132,7 +132,7 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
                 for vehicle in vehicles:
                     if vehicle:
                         await hass.async_add_executor_job(
-                            _run_pytoyoda_sync, vehicle.update
+                            _run_pytoyoda_sync, vehicle.update()
                         )
                         vehicle_data = VehicleData(
                             data=vehicle, statistics=None, metric_values=metric_values

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -142,17 +142,20 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
                             # Use parallel request to get car statistics.
                             driving_statistics = await asyncio.gather(
                                 hass.async_add_executor_job(
-                                    _run_pytoyoda_sync, vehicle.get_current_day_summary
-                                ),
-                                hass.async_add_executor_job(
-                                    _run_pytoyoda_sync, vehicle.get_current_week_summary
+                                    _run_pytoyoda_sync,
+                                    vehicle.get_current_day_summary(),
                                 ),
                                 hass.async_add_executor_job(
                                     _run_pytoyoda_sync,
-                                    vehicle.get_current_month_summary,
+                                    vehicle.get_current_week_summary(),
                                 ),
                                 hass.async_add_executor_job(
-                                    _run_pytoyoda_sync, vehicle.get_current_year_summary
+                                    _run_pytoyoda_sync,
+                                    vehicle.get_current_month_summary(),
+                                ),
+                                hass.async_add_executor_job(
+                                    _run_pytoyoda_sync,
+                                    vehicle.get_current_year_summary(),
                                 ),
                             )
 

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -77,7 +77,7 @@ class VehicleData(TypedDict):
     metric_values: bool
 
 
-def _run_pytoyoda_sync(coro: Coroutine) -> Coroutine:
+def _run_pytoyoda_sync(coro: Coroutine) -> Any:  # noqa : ANN401
     """Run a pytoyoda coroutine in a new event loop."""
     loop = asyncio.new_event_loop()
     try:

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -52,6 +52,8 @@ from pytoyoda.exceptions import (  # noqa: E402
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Coroutine
+
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from pytoyoda.models.summary import Summary
@@ -73,6 +75,15 @@ class VehicleData(TypedDict):
     data: Vehicle
     statistics: StatisticsData | None
     metric_values: bool
+
+
+def _run_pytoyoda_sync(coro: Coroutine) -> Coroutine:
+    """Run a pytoyoda coroutine in a new event loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0915, C901
@@ -113,13 +124,16 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
         """Fetch vehicle data from Toyota API."""
         try:
             vehicles = await asyncio.wait_for(
-                hass.async_add_executor_job(client.get_vehicles), 15
+                hass.async_add_executor_job(_run_pytoyoda_sync, client.get_vehicles()),
+                15,
             )
             vehicle_informations: list[VehicleData] = []
             if vehicles:
                 for vehicle in vehicles:
                     if vehicle:
-                        await hass.async_add_executor_job(vehicle.update)
+                        await hass.async_add_executor_job(
+                            _run_pytoyoda_sync, vehicle.update
+                        )
                         vehicle_data = VehicleData(
                             data=vehicle, statistics=None, metric_values=metric_values
                         )
@@ -128,16 +142,17 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
                             # Use parallel request to get car statistics.
                             driving_statistics = await asyncio.gather(
                                 hass.async_add_executor_job(
-                                    vehicle.get_current_day_summary
+                                    _run_pytoyoda_sync, vehicle.get_current_day_summary
                                 ),
                                 hass.async_add_executor_job(
-                                    vehicle.get_current_week_summary
+                                    _run_pytoyoda_sync, vehicle.get_current_week_summary
                                 ),
                                 hass.async_add_executor_job(
-                                    vehicle.get_current_month_summary
+                                    _run_pytoyoda_sync,
+                                    vehicle.get_current_month_summary,
                                 ),
                                 hass.async_add_executor_job(
-                                    vehicle.get_current_year_summary
+                                    _run_pytoyoda_sync, vehicle.get_current_year_summary
                                 ),
                             )
 


### PR DESCRIPTION
**Fixed blocking calls:**

`client.get_vehicles() → hass.async_add_executor_job(client.get_vehicles)`
`vehicle.update() → hass.async_add_executor_job(vehicle.update)`

**Statistics calls →** All four `vehicle.get_*_summary()` methods were moved to executor jobs:
*   `vehicle.get_current_day_summary()`
*   `vehicle.get_current_week_summary()`
*   `vehicle.get_current_month_summary()`
*   `vehicle.get_current_year_summary()`

**Why this solution works:**

*   `hass.async_add_executor_job()` executes synchronous/blocking functions in a separate thread pool.
*   This prevents SSL calls from blocking the Home Assistant event loop.
*   The functions remain awaitable and can be called with `await`.
*   `asyncio.gather()` still works in parallel, but it executes each call in a separate thread.

**Result:**

The Home Assistant warning “Detected blocking call to load_verify_locations inside the event loop” should no longer appear, because all HTTP/SSL calls are now correctly executed in executor threads instead of blocking the main event loop.