### PR TITLE
Add charging status

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,23 +80,25 @@ See [here](https://github.com/widewing/ha-toyota-na) for North America.
 
 ### Sensor(s)
 
-| <div style="width:250px">Name</div>            | Description                                            |
-| ---------------------------------------------- | ------------------------------------------------------ |
-| `sensor.<you_car_alias>_vin`                   | Static data about your car.                            |
-| `sensor.<you_car_alias>_odometer`              | Odometer information.                                  |
-| `sensor.<you_car_alias>_fuel_level`            | Fuel level information.                                |
-| `sensor.<you_car_alias>_fuel_range`            | Fuel range information.                                |
-| `sensor.<you_car_alias>_battery_level`         | Battery level information.                             |
-| `sensor.<you_car_alias>_battery_range`         | Battery range information.                             |
-| `sensor.<you_car_alias>_battery_range_ac`      | Battery range information when AC is on.               |
-| `sensor.<you_car_alias>_total_range`           | Information about combined fuel and battery range.     |
-| `sensor.<you_car_alias>_charging_status`       | Charging status (Charging, Not connected, Plugged in). |
-| `sensor.<you_car_alias>_remaining_charge_time` | Remaining minutes until charging is complete.          |
-| `sensor.<you_car_alias>_current_day_stats`     | Statistics for current day.                            |
-| `sensor.<you_car_alias>_current_week_stats`    | Statistics for current week.                           |
-| `sensor.<you_car_alias>_current_month_stats`   | Statistics for current month.                          |
-| `sensor.<you_car_alias>_current_year_stats`    | Statistics for current year.                           |
+| <div style="width:250px">Name</div>            | Description                                                             |
+| ---------------------------------------------- | ----------------------------------------------------------------------- |
+| `sensor.<you_car_alias>_vin`                   | Static data about your car.                                             |
+| `sensor.<you_car_alias>_odometer`              | Odometer information.                                                   |
+| `sensor.<you_car_alias>_fuel_level`            | Fuel level information.                                                 |
+| `sensor.<you_car_alias>_fuel_range`            | Fuel range information.                                                 |
+| `sensor.<you_car_alias>_battery_level`         | Battery level information.                                              |
+| `sensor.<you_car_alias>_battery_range`         | Battery range information.                                              |
+| `sensor.<you_car_alias>_battery_range_ac`      | Battery range information when AC is on.                                |
+| `sensor.<you_car_alias>_total_range`           | Information about combined fuel and battery range.                      |
+| `sensor.<you_car_alias>_charging_status`       | Charging status\* |
+| `sensor.<you_car_alias>_remaining_charge_time` | Remaining minutes until charging is complete.                           |
+| `sensor.<you_car_alias>_current_day_stats`     | Statistics for current day.                                             |
+| `sensor.<you_car_alias>_current_week_stats`    | Statistics for current week.                                            |
+| `sensor.<you_car_alias>_current_month_stats`   | Statistics for current month.                                           |
+| `sensor.<you_car_alias>_current_year_stats`    | Statistics for current year.                                            |
 
+
+\* *Possible charging states*: `Charge complete` | `Charging` | `Not connected` | `Plugged in`
 ### Statistics sensors
 
 #### Important

--- a/README.md
+++ b/README.md
@@ -80,25 +80,25 @@ See [here](https://github.com/widewing/ha-toyota-na) for North America.
 
 ### Sensor(s)
 
-| <div style="width:250px">Name</div>            | Description                                                             |
-| ---------------------------------------------- | ----------------------------------------------------------------------- |
-| `sensor.<you_car_alias>_vin`                   | Static data about your car.                                             |
-| `sensor.<you_car_alias>_odometer`              | Odometer information.                                                   |
-| `sensor.<you_car_alias>_fuel_level`            | Fuel level information.                                                 |
-| `sensor.<you_car_alias>_fuel_range`            | Fuel range information.                                                 |
-| `sensor.<you_car_alias>_battery_level`         | Battery level information.                                              |
-| `sensor.<you_car_alias>_battery_range`         | Battery range information.                                              |
-| `sensor.<you_car_alias>_battery_range_ac`      | Battery range information when AC is on.                                |
-| `sensor.<you_car_alias>_total_range`           | Information about combined fuel and battery range.                      |
-| `sensor.<you_car_alias>_charging_status`       | Charging status\* |
-| `sensor.<you_car_alias>_remaining_charge_time` | Remaining minutes until charging is complete.                           |
-| `sensor.<you_car_alias>_current_day_stats`     | Statistics for current day.                                             |
-| `sensor.<you_car_alias>_current_week_stats`    | Statistics for current week.                                            |
-| `sensor.<you_car_alias>_current_month_stats`   | Statistics for current month.                                           |
-| `sensor.<you_car_alias>_current_year_stats`    | Statistics for current year.                                            |
+| <div style="width:250px">Name</div>            | Description                                        |
+| ---------------------------------------------- | -------------------------------------------------- |
+| `sensor.<you_car_alias>_vin`                   | Static data about your car.                        |
+| `sensor.<you_car_alias>_odometer`              | Odometer information.                              |
+| `sensor.<you_car_alias>_fuel_level`            | Fuel level information.                            |
+| `sensor.<you_car_alias>_fuel_range`            | Fuel range information.                            |
+| `sensor.<you_car_alias>_battery_level`         | Battery level information.                         |
+| `sensor.<you_car_alias>_battery_range`         | Battery range information.                         |
+| `sensor.<you_car_alias>_battery_range_ac`      | Battery range information when AC is on.           |
+| `sensor.<you_car_alias>_total_range`           | Information about combined fuel and battery range. |
+| `sensor.<you_car_alias>_charging_status`       | Charging status\*                                  |
+| `sensor.<you_car_alias>_remaining_charge_time` | Remaining minutes until charging is complete.      |
+| `sensor.<you_car_alias>_current_day_stats`     | Statistics for current day.                        |
+| `sensor.<you_car_alias>_current_week_stats`    | Statistics for current week.                       |
+| `sensor.<you_car_alias>_current_month_stats`   | Statistics for current month.                      |
+| `sensor.<you_car_alias>_current_year_stats`    | Statistics for current year.                       |
 
+\* _Possible charging states_: `Charge complete` | `Charging` | `Not connected` | `Plugged in`
 
-\* *Possible charging states*: `Charge complete` | `Charging` | `Not connected` | `Plugged in`
 ### Statistics sensors
 
 #### Important

--- a/README.md
+++ b/README.md
@@ -80,20 +80,22 @@ See [here](https://github.com/widewing/ha-toyota-na) for North America.
 
 ### Sensor(s)
 
-| <div style="width:250px">Name</div>          | Description                                        |
-| -------------------------------------------- | -------------------------------------------------- |
-| `sensor.<you_car_alias>_vin`                 | Static data about your car.                        |
-| `sensor.<you_car_alias>_odometer`            | Odometer information.                              |
-| `sensor.<you_car_alias>_fuel_level`          | Fuel level information.                            |
-| `sensor.<you_car_alias>_fuel_range`          | Fuel range information.                            |
-| `sensor.<you_car_alias>_battery_level`       | Battery level information.                         |
-| `sensor.<you_car_alias>_battery_range`       | Battery range information.                         |
-| `sensor.<you_car_alias>_battery_range_ac`    | Battery range information when AC is on.           |
-| `sensor.<you_car_alias>_total_range`         | Information about combined fuel and battery range. |
-| `sensor.<you_car_alias>_current_day_stats`   | Statistics for current day.                        |
-| `sensor.<you_car_alias>_current_week_stats`  | Statistics for current week.                       |
-| `sensor.<you_car_alias>_current_month_stats` | Statistics for current month.                      |
-| `sensor.<you_car_alias>_current_year_stats`  | Statistics for current year.                       |
+| <div style="width:250px">Name</div>            | Description                                            |
+| ---------------------------------------------- | ------------------------------------------------------ |
+| `sensor.<you_car_alias>_vin`                   | Static data about your car.                            |
+| `sensor.<you_car_alias>_odometer`              | Odometer information.                                  |
+| `sensor.<you_car_alias>_fuel_level`            | Fuel level information.                                |
+| `sensor.<you_car_alias>_fuel_range`            | Fuel range information.                                |
+| `sensor.<you_car_alias>_battery_level`         | Battery level information.                             |
+| `sensor.<you_car_alias>_battery_range`         | Battery range information.                             |
+| `sensor.<you_car_alias>_battery_range_ac`      | Battery range information when AC is on.               |
+| `sensor.<you_car_alias>_total_range`           | Information about combined fuel and battery range.     |
+| `sensor.<you_car_alias>_charging_status`       | Charging status (Charging, Not connected, Plugged in). |
+| `sensor.<you_car_alias>_remaining_charge_time` | Remaining minutes until charging is complete.          |
+| `sensor.<you_car_alias>_current_day_stats`     | Statistics for current day.                            |
+| `sensor.<you_car_alias>_current_week_stats`    | Statistics for current week.                           |
+| `sensor.<you_car_alias>_current_month_stats`   | Statistics for current month.                          |
+| `sensor.<you_car_alias>_current_year_stats`    | Statistics for current year.                           |
 
 ### Statistics sensors
 

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -22,6 +22,7 @@ from .utils import (
     format_statistics_attributes,
     format_vin_sensor_attributes,
     round_number,
+    td_to_hoursminutes,
 )
 
 if TYPE_CHECKING:
@@ -186,10 +187,35 @@ CHARGING_STATUS_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
     attributes_fn=lambda vehicle: None
     if vehicle.dashboard is None
     else {
-        "remaining_minutes": (
-            vehicle.dashboard.remaining_charge_time.total_seconds() // 60
+        **(
+            {
+                "remaining_minutes": int(
+                    vehicle.dashboard.remaining_charge_time.total_seconds() // 60
+                )
+            }
             if vehicle.dashboard.remaining_charge_time is not None
-            else None
+            else {}
+        ),
+        "has_charging_schedule": vehicle.electric_status.has_active_charging_schedule
+        if hasattr(vehicle.electric_status, "has_active_charging_schedule")
+        else None,
+        **(
+            {
+                "scheduled_charging_start": (
+                    vehicle.electric_status.active_scheduled_charging.start
+                ),
+                "scheduled_charging_end": (
+                    vehicle.electric_status.active_scheduled_charging.end
+                ),
+                "scheduled_charging_duration": None
+                if vehicle.electric_status.active_scheduled_charging.duration is None
+                else td_to_hoursminutes(
+                    vehicle.electric_status.active_scheduled_charging.duration
+                ),
+            }
+            if hasattr(vehicle.electric_status, "has_active_charging_schedule")
+            and vehicle.electric_status.has_active_charging_schedule is not None
+            else {}
         ),
     },
 )

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -179,10 +179,10 @@ CHARGING_STATUS_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
     translation_key="charging_status",
     icon="mdi:ev-station",
     device_class=SensorDeviceClass.ENUM,
-    options=["charging", "none", "plugged"],
+    options=["chargeComplete", "charging", "none", "plugged"],
     value_fn=lambda vehicle: None
     if vehicle.dashboard is None
-    else vehicle.dashboard.charging_status,
+    else (vehicle.dashboard.charging_status),
     attributes_fn=lambda vehicle: None
     if vehicle.dashboard is None
     else {

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -182,7 +182,7 @@ CHARGING_STATUS_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
     options=["charging", "none", "plugged"],
     value_fn=lambda vehicle: None
     if vehicle.dashboard is None
-    else (vehicle.dashboard.charging_status),
+    else vehicle.dashboard.charging_status,
     attributes_fn=lambda vehicle: None
     if vehicle.dashboard is None
     else {

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -174,6 +174,37 @@ TOTAL_RANGE_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
     suggested_display_precision=0,
     attributes_fn=lambda vehicle: None,  # noqa : ARG005
 )
+CHARGING_STATUS_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
+    key="charging_status",
+    translation_key="charging_status",
+    icon="mdi:ev-station",
+    device_class=SensorDeviceClass.ENUM,
+    options=["charging", "none", "plugged"],
+    value_fn=lambda vehicle: None
+    if vehicle.dashboard is None
+    else (vehicle.dashboard.charging_status),
+    attributes_fn=lambda vehicle: None
+    if vehicle.dashboard is None
+    else {
+        "remaining_minutes": (
+            vehicle.dashboard.remaining_charge_time.total_seconds() // 60
+            if vehicle.dashboard.remaining_charge_time is not None
+            else None
+        ),
+    },
+)
+REMAINING_CHARGE_TIME_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
+    key="remaining_charge_time",
+    translation_key="remaining_charge_time",
+    icon="mdi:battery-clock",
+    device_class=SensorDeviceClass.DURATION,
+    state_class=SensorStateClass.MEASUREMENT,
+    suggested_display_precision=0,
+    value_fn=lambda vehicle: None
+    if (vehicle.dashboard is None or vehicle.dashboard.remaining_charge_time is None)
+    else (vehicle.dashboard.remaining_charge_time.total_seconds() // 60),
+    attributes_fn=lambda vehicle: None,  # noqa : ARG005
+)
 
 STATISTICS_ENTITY_DESCRIPTIONS_DAILY = ToyotaStatisticsSensorEntityDescription(
     key="current_day_statistics",
@@ -300,6 +331,24 @@ def create_sensor_configurations(metric_values: bool) -> list[dict[str, Any]]:  
             ),
             "native_unit": get_length_unit(metric_values),
             "suggested_unit": get_length_unit(metric_values),
+        },
+        {
+            "description": CHARGING_STATUS_ENTITY_DESCRIPTION,
+            "capability_check": lambda v: get_vehicle_capability(
+                v, "econnect_vehicle_status_capable"
+            )
+            or v.type == "electric",
+            "native_unit": None,
+            "suggested_unit": None,
+        },
+        {
+            "description": REMAINING_CHARGE_TIME_ENTITY_DESCRIPTION,
+            "capability_check": lambda v: get_vehicle_capability(
+                v, "econnect_vehicle_status_capable"
+            )
+            or v.type == "electric",
+            "native_unit": "min",
+            "suggested_unit": "min",
         },
         {
             "description": STATISTICS_ENTITY_DESCRIPTIONS_DAILY,

--- a/custom_components/toyota/translations/ca.json
+++ b/custom_components/toyota/translations/ca.json
@@ -67,6 +67,18 @@
         "state_attributes": {
           "remaining_minutes": {
             "name": "Minuts fins a ple"
+          },
+          "has_charging_schedule": {
+            "name": "Té horari de càrrega"
+          },
+          "scheduled_charging_start": {
+            "name": "Inici de càrrega programada"
+          },
+          "scheduled_charging_end": {
+            "name": "Final de càrrega programada"
+          },
+          "scheduled_charging_duration": {
+            "name": "Durada de la càrrega programada"
           }
         }
       },

--- a/custom_components/toyota/translations/ca.json
+++ b/custom_components/toyota/translations/ca.json
@@ -56,6 +56,22 @@
       "total_range": {
         "name": "Total range"
       },
+      "charging_status": {
+        "name": "Estat de càrrega",
+        "state": {
+          "charging": "Carregant",
+          "none": "No connectat",
+          "plugged": "Endollat"
+        },
+        "state_attributes": {
+          "remaining_minutes": {
+            "name": "Minuts fins a ple"
+          }
+        }
+      },
+      "remaining_charge_time": {
+        "name": "Temps de càrrega restant"
+      },
       "current_day_statistics": {
         "name": "Current day statistics"
       },

--- a/custom_components/toyota/translations/ca.json
+++ b/custom_components/toyota/translations/ca.json
@@ -59,6 +59,7 @@
       "charging_status": {
         "name": "Estat de càrrega",
         "state": {
+          "chargeComplete": "Càrrega completa",
           "charging": "Carregant",
           "none": "No connectat",
           "plugged": "Endollat"

--- a/custom_components/toyota/translations/cz.json
+++ b/custom_components/toyota/translations/cz.json
@@ -76,6 +76,18 @@
         "state_attributes": {
           "remaining_minutes": {
             "name": "Minut do plného nabití"
+          },
+          "has_charging_schedule": {
+            "name": "Má plán nabíjení"
+          },
+          "scheduled_charging_start": {
+            "name": "Plánovaný začátek nabíjení"
+          },
+          "scheduled_charging_end": {
+            "name": "Plánovaný konec nabíjení"
+          },
+          "scheduled_charging_duration": {
+            "name": "Doba trvání plánovaného nabíjení"
           }
         }
       },

--- a/custom_components/toyota/translations/cz.json
+++ b/custom_components/toyota/translations/cz.json
@@ -65,6 +65,22 @@
       "total_range": {
         "name": "Celkový dojezd"
       },
+      "charging_status": {
+        "name": "Stav nabíjení",
+        "state": {
+          "charging": "Nabíjení",
+          "none": "Nepřipojeno",
+          "plugged": "Připojeno"
+        },
+        "state_attributes": {
+          "remaining_minutes": {
+            "name": "Minut do plného nabití"
+          }
+        }
+      },
+      "remaining_charge_time": {
+        "name": "Zbývající doba nabíjení"
+      },
       "current_day_statistics": {
         "name": "Statistiky aktuálního dne"
       },

--- a/custom_components/toyota/translations/cz.json
+++ b/custom_components/toyota/translations/cz.json
@@ -68,6 +68,7 @@
       "charging_status": {
         "name": "Stav nabíjení",
         "state": {
+          "chargeComplete": "Nabíjení dokončeno",
           "charging": "Nabíjení",
           "none": "Nepřipojeno",
           "plugged": "Připojeno"

--- a/custom_components/toyota/translations/da.json
+++ b/custom_components/toyota/translations/da.json
@@ -76,6 +76,18 @@
         "state_attributes": {
           "remaining_minutes": {
             "name": "Minutter til fuld"
+          },
+          "has_charging_schedule": {
+            "name": "Har opladningsplan"
+          },
+          "scheduled_charging_start": {
+            "name": "Planlagt start for opladning"
+          },
+          "scheduled_charging_end": {
+            "name": "Planlagt afslutning af opladning"
+          },
+          "scheduled_charging_duration": {
+            "name": "Varighed af planlagt opladning"
           }
         }
       },

--- a/custom_components/toyota/translations/da.json
+++ b/custom_components/toyota/translations/da.json
@@ -65,6 +65,22 @@
       "total_range": {
         "name": "Total range"
       },
+      "charging_status": {
+        "name": "Opladningsstatus",
+        "state": {
+          "charging": "Oplader",
+          "none": "Ikke forbundet",
+          "plugged": "Tilsluttet"
+        },
+        "state_attributes": {
+          "remaining_minutes": {
+            "name": "Minutter til fuld"
+          }
+        }
+      },
+      "remaining_charge_time": {
+        "name": "Resterende opladningstid"
+      },
       "current_day_statistics": {
         "name": "Statistik for denne dag"
       },

--- a/custom_components/toyota/translations/da.json
+++ b/custom_components/toyota/translations/da.json
@@ -68,6 +68,7 @@
       "charging_status": {
         "name": "Opladningsstatus",
         "state": {
+          "chargeComplete": "Opladning færdig",
           "charging": "Oplader",
           "none": "Ikke forbundet",
           "plugged": "Tilsluttet"

--- a/custom_components/toyota/translations/de.json
+++ b/custom_components/toyota/translations/de.json
@@ -76,6 +76,18 @@
         "state_attributes": {
           "remaining_minutes": {
             "name": "Minuten bis voll"
+          },
+          "has_charging_schedule": {
+            "name": "Ladeplan aktiv"
+          },
+          "scheduled_charging_start": {
+            "name": "Geplanter Ladebeginn"
+          },
+          "scheduled_charging_end": {
+            "name": "Geplantes Ladeende"
+          },
+          "scheduled_charging_duration": {
+            "name": "Geplante Ladedauer"
           }
         }
       },

--- a/custom_components/toyota/translations/de.json
+++ b/custom_components/toyota/translations/de.json
@@ -68,6 +68,7 @@
       "charging_status": {
         "name": "Ladezustand",
         "state": {
+          "chargeComplete": "Ladevorgang abgeschlossen",
           "charging": "Lädt",
           "none": "Nicht verbunden",
           "plugged": "Eingesteckt"

--- a/custom_components/toyota/translations/de.json
+++ b/custom_components/toyota/translations/de.json
@@ -65,6 +65,22 @@
       "total_range": {
         "name": "Gesamtreichweite"
       },
+      "charging_status": {
+        "name": "Ladezustand",
+        "state": {
+          "charging": "Lädt",
+          "none": "Nicht verbunden",
+          "plugged": "Eingesteckt"
+        },
+        "state_attributes": {
+          "remaining_minutes": {
+            "name": "Minuten bis voll"
+          }
+        }
+      },
+      "remaining_charge_time": {
+        "name": "Verbleibende Ladezeit"
+      },
       "current_day_statistics": {
         "name": "Aktuelle Tagesstatistiken"
       },

--- a/custom_components/toyota/translations/en.json
+++ b/custom_components/toyota/translations/en.json
@@ -76,6 +76,18 @@
         "state_attributes": {
           "remaining_minutes": {
             "name": "Minutes until full"
+          },
+          "has_charging_schedule": {
+            "name": "Has charging schedule"
+          },
+          "scheduled_charging_start": {
+            "name": "Scheduled charging start"
+          },
+          "scheduled_charging_end": {
+            "name": "Scheduled charging end"
+          },
+          "scheduled_charging_duration": {
+            "name": "Scheduled charging duration"
           }
         }
       },

--- a/custom_components/toyota/translations/en.json
+++ b/custom_components/toyota/translations/en.json
@@ -68,6 +68,7 @@
       "charging_status": {
         "name": "Charging status",
         "state": {
+          "chargeComplete": "Charge complete",
           "charging": "Charging",
           "none": "Not connected",
           "plugged": "Plugged in"

--- a/custom_components/toyota/translations/en.json
+++ b/custom_components/toyota/translations/en.json
@@ -65,6 +65,22 @@
       "total_range": {
         "name": "Total range"
       },
+      "charging_status": {
+        "name": "Charging status",
+        "state": {
+          "charging": "Charging",
+          "none": "Not connected",
+          "plugged": "Plugged in"
+        },
+        "state_attributes": {
+          "remaining_minutes": {
+            "name": "Minutes until full"
+          }
+        }
+      },
+      "remaining_charge_time": {
+        "name": "Remaining charging time"
+      },
       "current_day_statistics": {
         "name": "Current day statistics"
       },

--- a/custom_components/toyota/translations/es.json
+++ b/custom_components/toyota/translations/es.json
@@ -66,7 +66,19 @@
         },
         "state_attributes": {
           "remaining_minutes": {
-            "name": "Minutos hasta lleno"
+            "name": "Minutos hasta cargado"
+          },
+          "has_charging_schedule": {
+            "name": "Tiene horario de carga"
+          },
+          "scheduled_charging_start": {
+            "name": "Inicio de carga programada"
+          },
+          "scheduled_charging_end": {
+            "name": "Fin de carga programada"
+          },
+          "scheduled_charging_duration": {
+            "name": "Duración de la carga programada"
           }
         }
       },

--- a/custom_components/toyota/translations/es.json
+++ b/custom_components/toyota/translations/es.json
@@ -59,6 +59,7 @@
       "charging_status": {
         "name": "Estado de carga",
         "state": {
+          "chargeComplete": "Carga completa",
           "charging": "Cargando",
           "none": "No conectado",
           "plugged": "Enchufado"

--- a/custom_components/toyota/translations/es.json
+++ b/custom_components/toyota/translations/es.json
@@ -56,6 +56,22 @@
       "total_range": {
         "name": "Total range"
       },
+      "charging_status": {
+        "name": "Estado de carga",
+        "state": {
+          "charging": "Cargando",
+          "none": "No conectado",
+          "plugged": "Enchufado"
+        },
+        "state_attributes": {
+          "remaining_minutes": {
+            "name": "Minutos hasta lleno"
+          }
+        }
+      },
+      "remaining_charge_time": {
+        "name": "Tiempo de carga restante"
+      },
       "current_day_statistics": {
         "name": "Estadísticas de hoy"
       },

--- a/custom_components/toyota/translations/fr.json
+++ b/custom_components/toyota/translations/fr.json
@@ -76,6 +76,18 @@
         "state_attributes": {
           "remaining_minutes": {
             "name": "Minutes jusqu'à plein"
+          },
+          "has_charging_schedule": {
+            "name": "A un planning de charge"
+          },
+          "scheduled_charging_start": {
+            "name": "Début de la charge planifiée"
+          },
+          "scheduled_charging_end": {
+            "name": "Fin de la charge planifiée"
+          },
+          "scheduled_charging_duration": {
+            "name": "Durée de la charge planifiée"
           }
         }
       },

--- a/custom_components/toyota/translations/fr.json
+++ b/custom_components/toyota/translations/fr.json
@@ -65,6 +65,22 @@
       "total_range": {
         "name": "Autonomie totale"
       },
+      "charging_status": {
+        "name": "État de charge",
+        "state": {
+          "charging": "En charge",
+          "none": "Non connecté",
+          "plugged": "Branché"
+        },
+        "state_attributes": {
+          "remaining_minutes": {
+            "name": "Minutes jusqu'à plein"
+          }
+        }
+      },
+      "remaining_charge_time": {
+        "name": "Temps de charge restant"
+      },
       "current_day_statistics": {
         "name": "Statistiques aujourd'hui"
       },

--- a/custom_components/toyota/translations/fr.json
+++ b/custom_components/toyota/translations/fr.json
@@ -68,6 +68,7 @@
       "charging_status": {
         "name": "État de charge",
         "state": {
+          "chargeComplete": "Charge complète",
           "charging": "En charge",
           "none": "Non connecté",
           "plugged": "Branché"

--- a/custom_components/toyota/translations/hu.json
+++ b/custom_components/toyota/translations/hu.json
@@ -68,6 +68,7 @@
       "charging_status": {
         "name": "Töltési állapot",
         "state": {
+          "chargeComplete": "Töltés kész",
           "charging": "Töltés",
           "none": "Nincs csatlakoztatva",
           "plugged": "Csatlakoztatva"

--- a/custom_components/toyota/translations/hu.json
+++ b/custom_components/toyota/translations/hu.json
@@ -65,6 +65,22 @@
       "total_range": {
         "name": "Teljes hatótávolság"
       },
+      "charging_status": {
+        "name": "Töltési állapot",
+        "state": {
+          "charging": "Töltés",
+          "none": "Nincs csatlakoztatva",
+          "plugged": "Csatlakoztatva"
+        },
+        "state_attributes": {
+          "remaining_minutes": {
+            "name": "Perc a teljes töltésig"
+          }
+        }
+      },
+      "remaining_charge_time": {
+        "name": "Hátralévő töltési idő"
+      },
       "current_day_statistics": {
         "name": "Mai napi statisztika"
       },

--- a/custom_components/toyota/translations/hu.json
+++ b/custom_components/toyota/translations/hu.json
@@ -76,6 +76,18 @@
         "state_attributes": {
           "remaining_minutes": {
             "name": "Perc a teljes töltésig"
+          },
+          "has_charging_schedule": {
+            "name": "Van töltési ütemezés"
+          },
+          "scheduled_charging_start": {
+            "name": "Ütemezett töltés kezdete"
+          },
+          "scheduled_charging_end": {
+            "name": "Ütemezett töltés vége"
+          },
+          "scheduled_charging_duration": {
+            "name": "Ütemezett töltés időtartama"
           }
         }
       },

--- a/custom_components/toyota/translations/it.json
+++ b/custom_components/toyota/translations/it.json
@@ -68,6 +68,7 @@
       "charging_status": {
         "name": "Stato di carica",
         "state": {
+          "chargeComplete": "Carica completa",
           "charging": "In carica",
           "none": "Non collegato",
           "plugged": "Collegato"

--- a/custom_components/toyota/translations/it.json
+++ b/custom_components/toyota/translations/it.json
@@ -76,6 +76,18 @@
         "state_attributes": {
           "remaining_minutes": {
             "name": "Minuti al completamento"
+          },
+          "has_charging_schedule": {
+            "name": "Ha orario di ricarica"
+          },
+          "scheduled_charging_start": {
+            "name": "Inizio ricarica programmata"
+          },
+          "scheduled_charging_end": {
+            "name": "Fine ricarica programmata"
+          },
+          "scheduled_charging_duration": {
+            "name": "Durata ricarica programmata"
           }
         }
       },

--- a/custom_components/toyota/translations/it.json
+++ b/custom_components/toyota/translations/it.json
@@ -65,6 +65,22 @@
       "total_range": {
         "name": "Percorrenza Totale"
       },
+      "charging_status": {
+        "name": "Stato di carica",
+        "state": {
+          "charging": "In carica",
+          "none": "Non collegato",
+          "plugged": "Collegato"
+        },
+        "state_attributes": {
+          "remaining_minutes": {
+            "name": "Minuti al completamento"
+          }
+        }
+      },
+      "remaining_charge_time": {
+        "name": "Tempo di ricarica rimanente"
+      },
       "current_day_statistics": {
         "name": "Statistiche di oggi"
       },

--- a/custom_components/toyota/translations/nb.json
+++ b/custom_components/toyota/translations/nb.json
@@ -68,6 +68,7 @@
       "charging_status": {
         "name": "Ladestatus",
         "state": {
+          "chargeComplete": "Lading fullført",
           "charging": "Lader",
           "none": "Ikke tilkoblet",
           "plugged": "Tilkoblet"

--- a/custom_components/toyota/translations/nb.json
+++ b/custom_components/toyota/translations/nb.json
@@ -76,6 +76,18 @@
         "state_attributes": {
           "remaining_minutes": {
             "name": "Minutter til fullt"
+          },
+          "has_charging_schedule": {
+            "name": "Har ladeplan"
+          },
+          "scheduled_charging_start": {
+            "name": "Planlagt start for lading"
+          },
+          "scheduled_charging_end": {
+            "name": "Planlagt slutt for lading"
+          },
+          "scheduled_charging_duration": {
+            "name": "Varighet av planlagt lading"
           }
         }
       },

--- a/custom_components/toyota/translations/nb.json
+++ b/custom_components/toyota/translations/nb.json
@@ -65,6 +65,22 @@
       "total_range": {
         "name": "Total range"
       },
+      "charging_status": {
+        "name": "Ladestatus",
+        "state": {
+          "charging": "Lader",
+          "none": "Ikke tilkoblet",
+          "plugged": "Tilkoblet"
+        },
+        "state_attributes": {
+          "remaining_minutes": {
+            "name": "Minutter til fullt"
+          }
+        }
+      },
+      "remaining_charge_time": {
+        "name": "Gjenværende ladetid"
+      },
       "current_day_statistics": {
         "name": "Current day statistics"
       },

--- a/custom_components/toyota/translations/nl.json
+++ b/custom_components/toyota/translations/nl.json
@@ -56,6 +56,22 @@
       "total_range": {
         "name": "Total range"
       },
+      "charging_status": {
+        "name": "Laadstatus",
+        "state": {
+          "charging": "Laden",
+          "none": "Niet verbonden",
+          "plugged": "Aangesloten"
+        },
+        "state_attributes": {
+          "remaining_minutes": {
+            "name": "Minuten tot vol"
+          }
+        }
+      },
+      "remaining_charge_time": {
+        "name": "Resterende laadtijd"
+      },
       "current_day_statistics": {
         "name": "Current day statistics"
       },

--- a/custom_components/toyota/translations/nl.json
+++ b/custom_components/toyota/translations/nl.json
@@ -67,6 +67,18 @@
         "state_attributes": {
           "remaining_minutes": {
             "name": "Minuten tot vol"
+          },
+          "has_charging_schedule": {
+            "name": "Heeft laadplanning"
+          },
+          "scheduled_charging_start": {
+            "name": "Geplande laadstart"
+          },
+          "scheduled_charging_end": {
+            "name": "Geplande laad-einde"
+          },
+          "scheduled_charging_duration": {
+            "name": "Duur van geplande lading"
           }
         }
       },

--- a/custom_components/toyota/translations/nl.json
+++ b/custom_components/toyota/translations/nl.json
@@ -59,6 +59,7 @@
       "charging_status": {
         "name": "Laadstatus",
         "state": {
+          "chargeComplete": "Laden voltooid",
           "charging": "Laden",
           "none": "Niet verbonden",
           "plugged": "Aangesloten"

--- a/custom_components/toyota/translations/pl.json
+++ b/custom_components/toyota/translations/pl.json
@@ -76,6 +76,18 @@
         "state_attributes": {
           "remaining_minutes": {
             "name": "Minuty do pełnego naładowania"
+          },
+          "has_charging_schedule": {
+            "name": "Ma harmonogram ładowania"
+          },
+          "scheduled_charging_start": {
+            "name": "Rozpoczęcie zaplanowanego ładowania"
+          },
+          "scheduled_charging_end": {
+            "name": "Zakończenie zaplanowanego ładowania"
+          },
+          "scheduled_charging_duration": {
+            "name": "Czas trwania zaplanowanego ładowania"
           }
         }
       },

--- a/custom_components/toyota/translations/pl.json
+++ b/custom_components/toyota/translations/pl.json
@@ -68,6 +68,7 @@
       "charging_status": {
         "name": "Stan ładowania",
         "state": {
+          "chargeComplete": "Ładowanie zakończone",
           "charging": "Ładowanie",
           "none": "Niepodłączony",
           "plugged": "Podłączony"

--- a/custom_components/toyota/translations/pl.json
+++ b/custom_components/toyota/translations/pl.json
@@ -65,6 +65,22 @@
       "total_range": {
         "name": "Całkowity zasięg"
       },
+      "charging_status": {
+        "name": "Stan ładowania",
+        "state": {
+          "charging": "Ładowanie",
+          "none": "Niepodłączony",
+          "plugged": "Podłączony"
+        },
+        "state_attributes": {
+          "remaining_minutes": {
+            "name": "Minuty do pełnego naładowania"
+          }
+        }
+      },
+      "remaining_charge_time": {
+        "name": "Pozostały czas ładowania"
+      },
       "current_day_statistics": {
         "name": "Statystyki bieżącego dnia"
       },

--- a/custom_components/toyota/translations/pt-pt.json
+++ b/custom_components/toyota/translations/pt-pt.json
@@ -68,6 +68,7 @@
       "charging_status": {
         "name": "Estado de carregamento",
         "state": {
+          "chargeComplete": "Carregamento concluído",
           "charging": "A carregar",
           "none": "Não ligado",
           "plugged": "Ligado"

--- a/custom_components/toyota/translations/pt-pt.json
+++ b/custom_components/toyota/translations/pt-pt.json
@@ -65,6 +65,22 @@
       "total_range": {
         "name": "Autonomia total"
       },
+      "charging_status": {
+        "name": "Estado de carregamento",
+        "state": {
+          "charging": "A carregar",
+          "none": "Não ligado",
+          "plugged": "Ligado"
+        },
+        "state_attributes": {
+          "remaining_minutes": {
+            "name": "Minutos até cheio"
+          }
+        }
+      },
+      "remaining_charge_time": {
+        "name": "Tempo de carregamento restante"
+      },
       "current_day_statistics": {
         "name": "Current day statistics"
       },

--- a/custom_components/toyota/translations/pt-pt.json
+++ b/custom_components/toyota/translations/pt-pt.json
@@ -76,6 +76,18 @@
         "state_attributes": {
           "remaining_minutes": {
             "name": "Minutos até cheio"
+          },
+          "has_charging_schedule": {
+            "name": "Tem hora de carregamento"
+          },
+          "scheduled_charging_start": {
+            "name": "Início do carregamento agendado"
+          },
+          "scheduled_charging_end": {
+            "name": "Fim do carregamento agendado"
+          },
+          "scheduled_charging_duration": {
+            "name": "Duração do carregamento agendado"
           }
         }
       },

--- a/custom_components/toyota/utils.py
+++ b/custom_components/toyota/utils.py
@@ -9,8 +9,19 @@ from typing import TYPE_CHECKING
 from .const import CONF_BRAND_MAPPING
 
 if TYPE_CHECKING:
+    from datetime import timedelta
+
     from pytoyoda.models.endpoints.vehicle_guid import VehicleGuidModel
     from pytoyoda.models.summary import Summary
+
+
+def td_to_hoursminutes(td: timedelta | None) -> str | None:
+    """Convert a timedelta to hours and minutes string."""
+    if td is None:
+        return None
+    total_minutes = int(td.total_seconds()) // 60
+    hours, minutes = divmod(total_minutes, 60)
+    return f"{hours}:{minutes}"
 
 
 def round_number(number: float | None, places: int = 0) -> int | float | None:


### PR DESCRIPTION
The electic status and the dashboard are already populated with information regarding the charging status and remaining charge time on the pytoyoda side.
This PR exposes those as sensors to HA.

Addresses #217 

<img width="580" height="606" alt="image" src="https://github.com/user-attachments/assets/e4baf230-6f58-4551-bfcf-30dd2dd61125" />

<img width="318" height="463" alt="image" src="https://github.com/user-attachments/assets/07c1dd8d-40c6-41a9-8b6f-c1d3c8af016d" />

