### PR TITLE
feat: smart status-refresh strategy + 429 resilience + #87 null-render fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@
   - [Binary sensor(s)](#binary-sensor-s-)
   - [Device tracker(s)](#device-tracker-s-)
   - [Sensor(s)](#sensor-s-)
+  - [Button(s)](#button-s-)
+  - [Service(s)](#service-s-)
+  - [Smart status refresh](#smart-status-refresh)
   - [Statistics sensors](#statistics-sensors)
     - [Important](#important)
     - [Attributes available](#attributes-available)
@@ -32,6 +35,7 @@
     - [Git clone method](#git-clone-method)
     - [Copy method](#copy-method)
   - [Integration Setup](#integration-setup)
+  - [Configuration](#configuration)
 - [Contribution](#contribution)
   - [License](#license)
 - [Credits](#credits)
@@ -62,6 +66,12 @@ See [here](https://github.com/widewing/ha-toyota-na) for North America.
 - Fuel, battery and odometer information
 - Current day, week, month and year statistics.
 - Door and door lock sensors, including hood and trunk sensor.
+- Diagnostic sensors for fetch health and cache freshness.
+- Smart status refresh: wake the vehicle on demand or automatically when it
+  has just stopped, mimicking the Toyota app's two-stage protocol so that
+  lock/door/window/hood state reflects reality instead of getting stuck stale.
+- Per-vehicle button to trigger a manual wake from the dashboard, plus a
+  `toyota.refresh_vehicle_status` service for use in automations.
 
 ### Binary sensor(s)
 
@@ -72,6 +82,10 @@ See [here](https://github.com/widewing/ha-toyota-na) for North America.
 | `binary_sensor.<you_car_alias>_*_lock`   | Lock sensors, one is created for each door and trunk. |
 | `binary_sensor.<you_car_alias>_*_window` | Window sensors, one is created for window.            |
 
+When the underlying vehicle status payload is missing a field (cold cache
+on first start, vehicle that does not report that field), these sensors
+read as `unknown` rather than falsely reporting `open` / `unlocked`.
+
 ### Device tracker(s)
 
 | <div style="width:250px">Name</div> | Description                         |
@@ -80,24 +94,95 @@ See [here](https://github.com/widewing/ha-toyota-na) for North America.
 
 ### Sensor(s)
 
-| <div style="width:250px">Name</div>            | Description                                        |
-| ---------------------------------------------- | -------------------------------------------------- |
-| `sensor.<you_car_alias>_vin`                   | Static data about your car.                        |
-| `sensor.<you_car_alias>_odometer`              | Odometer information.                              |
-| `sensor.<you_car_alias>_fuel_level`            | Fuel level information.                            |
-| `sensor.<you_car_alias>_fuel_range`            | Fuel range information.                            |
-| `sensor.<you_car_alias>_battery_level`         | Battery level information.                         |
-| `sensor.<you_car_alias>_battery_range`         | Battery range information.                         |
-| `sensor.<you_car_alias>_battery_range_ac`      | Battery range information when AC is on.           |
-| `sensor.<you_car_alias>_total_range`           | Information about combined fuel and battery range. |
-| `sensor.<you_car_alias>_charging_status`       | Charging status\*                                  |
-| `sensor.<you_car_alias>_remaining_charge_time` | Remaining minutes until charging is complete.      |
-| `sensor.<you_car_alias>_current_day_stats`     | Statistics for current day.                        |
-| `sensor.<you_car_alias>_current_week_stats`    | Statistics for current week.                       |
-| `sensor.<you_car_alias>_current_month_stats`   | Statistics for current month.                      |
-| `sensor.<you_car_alias>_current_year_stats`    | Statistics for current year.                       |
+| <div style="width:250px">Name</div>                  | Description                                                                                                                                   |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sensor.<you_car_alias>_vin`                         | Static data about your car.                                                                                                                   |
+| `sensor.<you_car_alias>_odometer`                    | Odometer information.                                                                                                                         |
+| `sensor.<you_car_alias>_fuel_level`                  | Fuel level information.                                                                                                                       |
+| `sensor.<you_car_alias>_fuel_range`                  | Fuel range information.                                                                                                                       |
+| `sensor.<you_car_alias>_battery_level`               | Battery level information.                                                                                                                    |
+| `sensor.<you_car_alias>_battery_range`               | Battery range information.                                                                                                                    |
+| `sensor.<you_car_alias>_battery_range_ac`            | Battery range information when AC is on.                                                                                                      |
+| `sensor.<you_car_alias>_total_range`                 | Information about combined fuel and battery range.                                                                                            |
+| `sensor.<you_car_alias>_charging_status`             | Charging status\*                                                                                                                             |
+| `sensor.<you_car_alias>_remaining_charge_time`       | Remaining minutes until charging is complete.                                                                                                 |
+| `sensor.<you_car_alias>_current_day_stats`           | Statistics for current day.                                                                                                                   |
+| `sensor.<you_car_alias>_current_week_stats`          | Statistics for current week.                                                                                                                  |
+| `sensor.<you_car_alias>_current_month_stats`         | Statistics for current month.                                                                                                                 |
+| `sensor.<you_car_alias>_current_year_stats`          | Statistics for current year.                                                                                                                  |
+| `sensor.<you_car_alias>_last_successful_fetch`       | Diagnostic: timestamp of the last successful refresh.                                                                                         |
+| `sensor.<you_car_alias>_last_error`                  | Diagnostic: timestamp of the last refresh error.                                                                                              |
+| `sensor.<you_car_alias>_last_error_code`             | Diagnostic: HTTP status or exception class of the last error.                                                                                 |
+| `sensor.<you_car_alias>_status_last_reported_by_car` | Diagnostic: `occurrence_date` of the most recent `/v1/global/remote/status` payload (i.e. when the car last transmitted its lock/door state). |
+| `sensor.<you_car_alias>_status_refresh_state`        | Diagnostic: smart-refresh state (`active` / `soft_disabled_unreachable` / `hard_disabled_auto` / `hard_disabled_user`).                       |
 
 \* _Possible charging states_: `Charge complete` | `Charging` | `Not connected` | `Plugged in`
+
+### Button(s)
+
+| <div style="width:250px">Name</div>             | Description                                                                        |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `button.<you_car_alias>_refresh_vehicle_status` | One-tap wake. Wraps `toyota.refresh_vehicle_status` for the corresponding vehicle. |
+
+### Service(s)
+
+| Service                         | Description                                                                                                                  |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `toyota.refresh_vehicle_status` | Wakes the vehicle's cellular modem and fetches a fresh door / lock / window / hood payload. Targets one or more `device_id`. |
+
+Service fields:
+
+| Field             | Default | Description                                                                      |
+| ----------------- | ------- | -------------------------------------------------------------------------------- |
+| `timeout_seconds` | `60`    | How long to wait for the car to transmit fresh data before returning (10 - 180). |
+
+Use sparingly: each call uses a small amount of cellular airtime and 12 V
+battery. For routine polling, the integration's smart strategy already
+picks the right moments (see below).
+
+### Smart status refresh
+
+Lock / door / window / hood data tends to get stuck stale. The Toyota mobile
+app issues a `POST /v1/global/remote/refresh-status` to wake the vehicle's
+modem before reading `/v1/global/remote/status`; doing the same in this
+integration empirically gives fresher payloads and reduces (but does not
+eliminate) the `429 APIGW-403` responses on the GET. We do not have a
+confirmed model for every 429 - some 429s are unrelated to cache state and
+look random - so the integration treats this as a best-effort improvement
+rather than a guarantee. When this option is on (default), the integration
+fires the wake POST under specific triggers; each wake costs a small amount
+of cellular airtime and 12 V battery, so the strategy gates WHEN to fire one:
+
+- **`just_stopped`**: the integration detects via the odometer that the vehicle
+  was driving last cycle and is stationary now, and fires a wake POST. A
+  configurable number of follow-up POSTs is fired on the immediately
+  following coordinator cycles (default 2 total POSTs per stop event) to
+  catch state the user changes shortly after stopping - locking the doors,
+  opening the trunk to grab bags, etc. - which trigger fresh modem reports
+  that the followup POSTs' poll loops pick up. This is the main path that
+  aims to address the stuck-stale reports in [#87], [#137], [#157],
+  [#190], [#229], [#281] and [#284] without any user action.
+- **`service_call`**: the user fires `toyota.refresh_vehicle_status` (via the
+  per-vehicle button or an automation). Bypasses soft-disable.
+- **`idle_wake`** (opt-in, default off): wakes the vehicle every N hours
+  even if it has not moved. Useful for cars that sit unused for days.
+- **`cache_stale`**: a regular GET if the cached payload is older than the
+  configured `max_cache_age_minutes` (default 30 minutes).
+
+Cars that do not respond to the wake POST (deeply parked Aygo, etc.) are
+**soft-disabled per VIN** after a configurable number of failed wakes (default
+3). Soft-disable auto-clears as soon as the car shows any sign of life
+(driving event, external app refresh, manual service call). Vehicles whose
+Toyota account does not support `/refresh-status` at all are **hard-disabled**
+automatically; the user clears this by toggling the master switch off then on.
+
+[#87]: https://github.com/pytoyoda/ha_toyota/issues/87
+[#137]: https://github.com/pytoyoda/ha_toyota/issues/137
+[#157]: https://github.com/pytoyoda/ha_toyota/issues/157
+[#190]: https://github.com/pytoyoda/ha_toyota/issues/190
+[#229]: https://github.com/pytoyoda/ha_toyota/issues/229
+[#281]: https://github.com/pytoyoda/ha_toyota/issues/281
+[#284]: https://github.com/pytoyoda/ha_toyota/issues/284
 
 ### Statistics sensors
 
@@ -187,6 +272,22 @@ Now you can clone the repository somewhere else and symlink it to Home Assistant
 - From the list, search and select “Toyota Connected Services”.
 - Follow the instruction on screen to complete the set-up.
 - After completing, the Toyota Connected Services integration will be immediately available for use.
+
+### Configuration
+
+After setup, options can be tuned per integration entry from
+**Settings → Devices & Services → Toyota Connected Services → Configure**.
+Defaults are tuned for a typical daily-driven car.
+
+| Option                                             | Default | Range   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| -------------------------------------------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Polling interval (minutes)**                     | 6       | 5 - 60  | How often the integration polls Toyota for fresh data. Lower values may hit rate limits.                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| **Retain last good data on transient failures**    | off     | toggle  | When a refresh fails (HTTP 429, timeout, connection error), keep the last successful per-vehicle data in place instead of flipping to `unavailable`. The diagnostic sensors above still surface the underlying failure.                                                                                                                                                                                                                                                                                   |
+| **Refresh vehicle status remotely**                | on      | toggle  | Master switch for the smart status refresh feature. Scope is only the `/v1/global/remote/status` endpoint (door / window / lock / hood); other data is fetched every cycle regardless. Disable for vehicles whose Toyota account does not support `/refresh-status`; the integration also auto-disables this for you when it detects unsupported responses. **When this option is OFF, the four options below (idle wake, failed-wake threshold, status cache age, wake POSTs per stop) have no effect.** |
+| **Wake idle vehicle every N hours (0 = disabled)** | 0       | 0 - 72  | Wake the car periodically even if it has not moved. Useful for cars that sit unused for days where you still want fresh lock state. 0 disables the feature; 1-72 fires a wake POST every N hours. Off by default to spare 12 V battery. The wake only refreshes the `/v1/global/remote/status` endpoint (door / window / lock / hood); other data is fetched every cycle regardless.                                                                                                                      |
+| **Mark unreachable after N failed wakes**          | 3       | 1 - 10  | A vehicle that fails to respond to this many consecutive wake POSTs is marked unreachable per-VIN. Auto-clears on any sign of life from the car.                                                                                                                                                                                                                                                                                                                                                          |
+| **Refresh status cache if older**                  | 30      | 5 - 180 | Maximum acceptable age of the cached `/status` data before issuing a fresh GET. Controls only the `/v1/global/remote/status` endpoint (door / window / lock / hood). Other data (odometer, fuel, location, etc.) is fetched every cycle regardless.                                                                                                                                                                                                                                                       |
+| **Wake POSTs per stop event**                      | 2       | 1 - 5   | Number of wake POSTs fired when a stop event is detected, one per coordinator cycle. 1 = single POST. 2 = an additional POST on the next cycle, which typically catches state the user changes shortly after stopping (locking the doors, opening the trunk) - those events trigger fresh modem reports that the second POST's poll loop picks up. Higher rarely helps and burns 12 V battery.                                                                                                            |
 
 ## Contribution
 

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -8,8 +8,7 @@ import asyncio
 import asyncio.exceptions as asyncioexceptions
 import logging
 from datetime import timedelta
-from functools import partial
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 import httpcore
 import httpx
@@ -52,8 +51,6 @@ from pytoyoda.exceptions import (  # noqa: E402
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Coroutine
-
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from pytoyoda.models.summary import Summary
@@ -77,15 +74,6 @@ class VehicleData(TypedDict):
     metric_values: bool
 
 
-def _run_pytoyoda_sync(coro: Coroutine) -> Any:  # noqa : ANN401
-    """Run a pytoyoda coroutine in a new event loop."""
-    loop = asyncio.new_event_loop()
-    try:
-        return loop.run_until_complete(coro)
-    finally:
-        loop.close()
-
-
 async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0915, C901
     hass: HomeAssistant, entry: ConfigEntry
 ) -> bool:
@@ -107,28 +95,15 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
 
     _LOGGER.info("Setting up %s integration (brand code: %s)", brand, brand_code)
 
-    client = await hass.async_add_executor_job(
-        partial(
-            MyT,
-            username=email,
-            password=password,
-            use_metric=metric_values,
-            brand=brand_code,  # Pass brand code to API client
-        )
+    client = MyT(
+        username=email,
+        password=password,
+        use_metric=metric_values,
+        brand=brand_code,
     )
 
     try:
-
-        def _sync_login() -> Any:  # noqa: ANN401
-            loop = asyncio.new_event_loop()
-            result = None
-            try:
-                result = loop.run_until_complete(client.login())
-            finally:
-                loop.close()
-            return result
-
-        await hass.async_add_executor_job(_sync_login)
+        await client.login()
     except ToyotaLoginError as ex:
         raise ConfigEntryAuthFailed(ex) from ex
     except (httpx.ConnectTimeout, httpcore.ConnectTimeout) as ex:
@@ -138,17 +113,12 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
     async def async_get_vehicle_data() -> list[VehicleData] | None:  # noqa: C901
         """Fetch vehicle data from Toyota API."""
         try:
-            vehicles = await asyncio.wait_for(
-                hass.async_add_executor_job(_run_pytoyoda_sync, client.get_vehicles()),
-                15,
-            )
+            vehicles = await asyncio.wait_for(client.get_vehicles(), 15)
             vehicle_informations: list[VehicleData] = []
             if vehicles:
                 for vehicle in vehicles:
                     if vehicle:
-                        await hass.async_add_executor_job(
-                            _run_pytoyoda_sync, vehicle.update()
-                        )
+                        await vehicle.update()
                         vehicle_data = VehicleData(
                             data=vehicle, statistics=None, metric_values=metric_values
                         )
@@ -156,22 +126,10 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
                         if vehicle.vin is not None:
                             # Use parallel request to get car statistics.
                             driving_statistics = await asyncio.gather(
-                                hass.async_add_executor_job(
-                                    _run_pytoyoda_sync,
-                                    vehicle.get_current_day_summary(),
-                                ),
-                                hass.async_add_executor_job(
-                                    _run_pytoyoda_sync,
-                                    vehicle.get_current_week_summary(),
-                                ),
-                                hass.async_add_executor_job(
-                                    _run_pytoyoda_sync,
-                                    vehicle.get_current_month_summary(),
-                                ),
-                                hass.async_add_executor_job(
-                                    _run_pytoyoda_sync,
-                                    vehicle.get_current_year_summary(),
-                                ),
+                                vehicle.get_current_day_summary(),
+                                vehicle.get_current_week_summary(),
+                                vehicle.get_current_month_summary(),
+                                vehicle.get_current_year_summary(),
                             )
 
                             vehicle_data["statistics"] = StatisticsData(

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import asyncio
 import asyncio.exceptions as asyncioexceptions
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, TypedDict
 
 import httpcore
@@ -15,10 +15,19 @@ import httpx
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 from loguru import logger
 from pydantic import ValidationError
 
-from .const import CONF_BRAND, CONF_METRIC_VALUES, DOMAIN, PLATFORMS, STARTUP_MESSAGE
+from .const import (
+    CONF_BRAND,
+    CONF_METRIC_VALUES,
+    CONF_RETAIN_ON_TRANSIENT_FAILURE,
+    DEFAULT_RETAIN_ON_TRANSIENT_FAILURE,
+    DOMAIN,
+    PLATFORMS,
+    STARTUP_MESSAGE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,6 +81,16 @@ class VehicleData(TypedDict):
     data: Vehicle
     statistics: StatisticsData | None
     metric_values: bool
+    # Observability fields, populated by the coordinator regardless of the
+    # CONF_RETAIN_ON_TRANSIENT_FAILURE toggle. Surfaced as timestamp +
+    # diagnostic sensors so users can see when their car data was last fresh
+    # and what the most recent Toyota-side hiccup was.
+    last_successful_fetch: datetime | None
+    last_error_time: datetime | None
+    last_error_code: str | None
+    # True when this poll's data is a cached fallback because the live fetch
+    # failed. Used by downstream sensors as a diagnostic.
+    is_cached: bool
 
 
 async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0915, C901
@@ -110,61 +129,191 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
         msg = "Unable to connect to Toyota Connected Services"
         raise ConfigEntryNotReady(msg) from ex
 
+    # Per-vehicle retain state. Keyed by VIN. The latest successful
+    # VehicleData for each car is kept so that when ONE car's refresh
+    # fails (e.g. Toyota 429s partway through the fleet sweep) we can
+    # keep that car visible with its last fresh data + a diagnostic
+    # last_error timestamp/code, while the other cars get fresh data.
+    # Without this, any single transient Toyota failure flips the
+    # entire fleet to unavailable.
+    #
+    # Three additional pieces of state are surfaced as HA sensors:
+    # - last_successful_fetch: when this car's data was last fresh
+    # - last_error_time: when this car last hit a Toyota-side error
+    # - last_error_code: the HTTP status or exception class of that error
+    #
+    # Gated behind CONF_RETAIN_ON_TRANSIENT_FAILURE so users who rely
+    # on "unavailable" state transitions in their automations can opt
+    # out. Default off for backward compatibility.
+    retain_on_transient: bool = entry.options.get(
+        CONF_RETAIN_ON_TRANSIENT_FAILURE, DEFAULT_RETAIN_ON_TRANSIENT_FAILURE
+    )
+    last_good_per_vin: dict[str, VehicleData] = {}
+    last_fetch_time_per_vin: dict[str, datetime] = {}
+    last_error_per_vin: dict[str, tuple[datetime, str]] = {}
+
+    def _error_code(exc: BaseException) -> str:
+        """Derive a short error-code string for the last_error sensor."""
+        msg = str(exc)
+        # Toyota 429s embed the status code in the ToyotaApiError message:
+        # "Request Failed. 429, {...}." Extract it when present.
+        for code in ("429", "500", "502", "503", "504"):
+            if f"Request Failed. {code}," in msg:
+                return f"HTTP {code}"
+        if isinstance(exc, (httpx.ConnectTimeout, httpcore.ConnectTimeout)):
+            return "connect timeout"
+        if isinstance(exc, (httpx.ReadTimeout, asyncioexceptions.TimeoutError)):
+            return "read timeout"
+        if isinstance(exc, asyncioexceptions.CancelledError):
+            return "cancelled"
+        if isinstance(exc, ToyotaApiError):
+            return "api error"
+        if isinstance(exc, ToyotaLoginError):
+            return "login error"
+        return type(exc).__name__
+
+    def _build_vehicle_data_from_cache(vin: str) -> VehicleData:
+        """Return a copy of the last-good VehicleData for a vin, with
+        refreshed error/timestamp fields. The Vehicle object itself is
+        the cached one, so all downstream sensors see the last values."""
+        cached = last_good_per_vin[vin]
+        err = last_error_per_vin.get(vin)
+        return VehicleData(
+            data=cached["data"],
+            statistics=cached["statistics"],
+            metric_values=cached["metric_values"],
+            last_successful_fetch=last_fetch_time_per_vin.get(vin),
+            last_error_time=err[0] if err else None,
+            last_error_code=err[1] if err else None,
+            is_cached=True,
+        )
+
+    async def _refresh_one_vehicle(vehicle: Vehicle) -> VehicleData:
+        """Fetch one vehicle's full data. Does NOT catch exceptions; caller
+        decides retain-vs-propagate policy based on config toggle."""
+        await vehicle.update()
+        statistics: StatisticsData | None = None
+        if vehicle.vin is not None:
+            # Serialised to avoid Toyota burst rate-limit. Firing these four
+            # summary calls in an asyncio.gather within the same event-loop
+            # tick reliably trips a 429 with {"description": "Unauthorized"}
+            # response bodies. See pytoyoda/ha_toyota#282.
+            statistics = StatisticsData(
+                day=await vehicle.get_current_day_summary(),
+                week=await vehicle.get_current_week_summary(),
+                month=await vehicle.get_current_month_summary(),
+                year=await vehicle.get_current_year_summary(),
+            )
+        now = dt_util.now()
+        if vehicle.vin is not None:
+            last_fetch_time_per_vin[vehicle.vin] = now
+        err = last_error_per_vin.get(vehicle.vin) if vehicle.vin else None
+        return VehicleData(
+            data=vehicle,
+            statistics=statistics,
+            metric_values=metric_values,
+            last_successful_fetch=now,
+            last_error_time=err[0] if err else None,
+            last_error_code=err[1] if err else None,
+            is_cached=False,
+        )
+
     async def async_get_vehicle_data() -> list[VehicleData] | None:  # noqa: C901
-        """Fetch vehicle data from Toyota API."""
+        """Fetch vehicle data from Toyota API, per-car error handling."""
+        # Step 1: get the vehicle list. This is account-level; if it fails
+        # we have no per-vehicle recovery path, but we CAN serve stale
+        # fleet data if any exists.
         try:
             vehicles = await asyncio.wait_for(client.get_vehicles(), 15)
-            vehicle_informations: list[VehicleData] = []
-            if vehicles:
-                for vehicle in vehicles:
-                    if vehicle:
-                        await vehicle.update()
-                        vehicle_data = VehicleData(
-                            data=vehicle, statistics=None, metric_values=metric_values
-                        )
-
-                        if vehicle.vin is not None:
-                            # Serialised to avoid Toyota burst rate-limit.
-                            # Toyota's API gateway throttles on bursts of
-                            # near-simultaneous requests; firing these four
-                            # summary calls in an asyncio.gather within the
-                            # same event-loop tick reliably trips a 429 with
-                            # {"description": "Unauthorized"} response
-                            # bodies. See pytoyoda/ha_toyota#282.
-                            vehicle_data["statistics"] = StatisticsData(
-                                day=await vehicle.get_current_day_summary(),
-                                week=await vehicle.get_current_week_summary(),
-                                month=await vehicle.get_current_month_summary(),
-                                year=await vehicle.get_current_year_summary(),
-                            )
-
-                        vehicle_informations.append(vehicle_data)
-
-                _LOGGER.debug(vehicle_informations)
-                return vehicle_informations
-
         except ToyotaLoginError:
+            # Credentials invalid - not transient, surface as auth error.
             _LOGGER.exception("Toyota login error")
-        except ToyotaInternalError as ex:
-            _LOGGER.debug(ex)
-        except ToyotaApiError as ex:
-            raise UpdateFailed(ex) from ex
-        except (httpx.ConnectTimeout, httpcore.ConnectTimeout) as ex:
-            msg = "Unable to connect to Toyota Connected Services"
-            raise UpdateFailed(msg) from ex
-        except ValidationError:
-            _LOGGER.exception("Toyota validation error")
+            return None
         except (
+            ToyotaApiError,
+            httpx.ConnectTimeout,
+            httpcore.ConnectTimeout,
             asyncioexceptions.CancelledError,
             asyncioexceptions.TimeoutError,
             httpx.ReadTimeout,
         ) as ex:
-            msg = (
-                "Update canceled! \n"
-                "Toyota's API was too slow to respond. Will try again later."
-            )
-            raise UpdateFailed(msg) from ex
-        return None
+            code = _error_code(ex)
+            now = dt_util.now()
+            for vin in last_good_per_vin:
+                last_error_per_vin[vin] = (now, code)
+            if retain_on_transient and last_good_per_vin:
+                _LOGGER.warning(
+                    "Toyota get_vehicles failed (%s); using cached fleet data", code
+                )
+                return [_build_vehicle_data_from_cache(vin) for vin in last_good_per_vin]
+            raise UpdateFailed(f"Toyota get_vehicles failed: {ex}") from ex
+        except ValidationError as ex:
+            _LOGGER.exception("Toyota validation error on get_vehicles")
+            code = "validation error"
+            now = dt_util.now()
+            for vin in last_good_per_vin:
+                last_error_per_vin[vin] = (now, code)
+            if retain_on_transient and last_good_per_vin:
+                return [_build_vehicle_data_from_cache(vin) for vin in last_good_per_vin]
+            return None
+
+        # Step 2: fetch each vehicle's data independently, so a failure on
+        # one does not drop the others. Per-vehicle error recovery honors
+        # the retain-on-transient toggle.
+        vehicle_informations: list[VehicleData] = []
+        for vehicle in vehicles or []:
+            if not vehicle or vehicle.vin is None:
+                continue
+            vin = vehicle.vin
+            try:
+                vehicle_data = await _refresh_one_vehicle(vehicle)
+                last_good_per_vin[vin] = vehicle_data
+                vehicle_informations.append(vehicle_data)
+            except (
+                ToyotaApiError,
+                ToyotaInternalError,
+                httpx.ConnectTimeout,
+                httpcore.ConnectTimeout,
+                asyncioexceptions.CancelledError,
+                asyncioexceptions.TimeoutError,
+                httpx.ReadTimeout,
+                ValidationError,
+            ) as ex:
+                code = _error_code(ex)
+                last_error_per_vin[vin] = (dt_util.now(), code)
+                _LOGGER.warning(
+                    "Toyota refresh failed for vin=...%s (%s)", vin[-6:], code
+                )
+                if retain_on_transient and vin in last_good_per_vin:
+                    vehicle_informations.append(_build_vehicle_data_from_cache(vin))
+                elif retain_on_transient:
+                    # No cache yet for this vehicle, but we must still emit a
+                    # VehicleData so its entities stay registered and just
+                    # report None state. Skipping would cause IndexError in
+                    # sensor platforms that hold vehicle_index references
+                    # from a previous successful refresh.
+                    vehicle_informations.append(
+                        VehicleData(
+                            data=vehicle,
+                            statistics=None,
+                            metric_values=metric_values,
+                            last_successful_fetch=None,
+                            last_error_time=dt_util.now(),
+                            last_error_code=code,
+                            is_cached=False,
+                        )
+                    )
+                # else (retain disabled): skip this vehicle. In this mode the
+                # coordinator will raise UpdateFailed if the rest of the
+                # fleet also fails, matching upstream behaviour.
+
+        if not vehicle_informations:
+            # Whole fleet failed and nothing cached anywhere. Coordinator
+            # handling: UpdateFailed flips entities to unavailable.
+            raise UpdateFailed("Toyota refresh failed for all vehicles")
+
+        _LOGGER.debug(vehicle_informations)
+        return vehicle_informations
 
     coordinator = DataUpdateCoordinator(
         hass,

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -59,6 +59,15 @@ from .refresh_strategy import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Default wake-poll budget in seconds. Used when POST_THEN_GET fires from a
+# non-service trigger (just_stopped, just_stopped_followup, idle_wake) -
+# i.e. the budget the strategy itself owns. Service-call triggers carry
+# their own user-supplied timeout via pending_service_calls and override
+# this default. Empirically the modem wakes within ~10-25s after a POST,
+# so 25s is enough for ~3 polls at 10s spacing without burning extra
+# requests against the gateway.
+STRATEGY_DEFAULT_WAKE_TIMEOUT_S = 25
+
 
 def loguru_to_hass(message: str) -> None:
     """Forward Loguru logs to standard Python logger used by HACS."""
@@ -244,8 +253,11 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
         diag_bucket.setdefault(new_key, {})
     # Pending service-call requests, keyed by VIN. The service handler sets a
     # value here and reload-triggers the coordinator; the next cycle picks it
-    # up via the strategy's user_service_call_pending input.
-    pending_service_calls: dict[str, bool] = diag_bucket.setdefault(
+    # up via the strategy's user_service_call_pending input. The dict value is
+    # the user-supplied wake-poll budget in seconds (services.yaml exposes
+    # `timeout_seconds`, default 60); non-service triggers (just_stopped,
+    # idle_wake, ...) fall through to STRATEGY_DEFAULT_WAKE_TIMEOUT_S below.
+    pending_service_calls: dict[str, int] = diag_bucket.setdefault(
         "pending_service_calls", {}
     )
     last_good_per_vin: dict[str, VehicleData] = diag_bucket["last_good_per_vin"]
@@ -367,15 +379,21 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
         )
 
     async def _execute_post_then_get(
-        vehicle: Vehicle, vin: str, state: VinState
+        vehicle: Vehicle,
+        vin: str,
+        state: VinState,
+        timeout_s: int = STRATEGY_DEFAULT_WAKE_TIMEOUT_S,
     ) -> None:
         """Issue POST /refresh-status, then poll GET /status until cache advances.
 
-        Polls until ``occurrence_date`` advances or a 25-second budget expires.
-        Mutates state in place per the caller contract in refresh_strategy.py.
-        Pytoyoda's controller already retries 429/5xx with exponential backoff,
-        so this loop only iterates if the gateway returned 200 with a stale
-        occurrence_date (legitimate "POST accepted but cache not yet warm").
+        Polls until ``occurrence_date`` advances or ``timeout_s`` seconds expire.
+        Defaults to STRATEGY_DEFAULT_WAKE_TIMEOUT_S for non-service triggers;
+        service-call triggers pass through the user-supplied
+        ``timeout_seconds`` from services.yaml. Mutates state in place per the
+        caller contract in refresh_strategy.py. Pytoyoda's controller already
+        retries 429/5xx with exponential backoff, so this loop only iterates
+        if the gateway returned 200 with a stale occurrence_date (legitimate
+        "POST accepted but cache not yet warm").
         """
         opts = _strategy_options()
         post_response = await _call_tagged(
@@ -416,9 +434,8 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
             return
         on_post_layer1_success(state)
 
-        # Layer 2: poll for occurrence_date advancement. 25-second budget
-        # split into ~3 attempts (10s spacing).
-        deadline = dt_util.now() + timedelta(seconds=25)
+        # Layer 2: poll for occurrence_date advancement.
+        deadline = dt_util.now() + timedelta(seconds=timeout_s)
         previous_occurrence = state.last_status_occurrence_date
         while dt_util.now() < deadline:
             await asyncio.sleep(10)
@@ -461,19 +478,24 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
         vin: str,
         state: VinState,
         decision: RefreshDecision,
+        wake_timeout_s: int = STRATEGY_DEFAULT_WAKE_TIMEOUT_S,
     ) -> None:
         """Execute the per-action /status path for one VIN.
 
         POST_THEN_GET also manages the cycle-based followup counter per the
         strategy's caller contract: JUST_STOPPED initialises it, followup
         cycles decrement, SERVICE_CALL / IDLE_WAKE leave it alone.
+
+        ``wake_timeout_s`` is forwarded to :func:`_execute_post_then_get` for
+        the SERVICE_CALL trigger (carrying the user-supplied timeout from
+        services.yaml). All other triggers fall through to the default.
         """
         if decision.action is RefreshAction.POST_THEN_GET:
             if decision.trigger is RefreshTrigger.JUST_STOPPED:
                 state.remaining_post_cycles = max(0, post_count_per_stop - 1)
             elif decision.trigger is RefreshTrigger.JUST_STOPPED_FOLLOWUP:
                 state.remaining_post_cycles = max(0, state.remaining_post_cycles - 1)
-            await _execute_post_then_get(vehicle, vin, state)
+            await _execute_post_then_get(vehicle, vin, state, wake_timeout_s)
         elif decision.action is RefreshAction.GET_ONLY:
             await _execute_get_only(vehicle, vin, state)
         elif decision.action is RefreshAction.HARD_DISABLED:
@@ -563,7 +585,11 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
             current_odometer_km = None
 
         state = _build_vin_state(vin) if vin else VinState()
-        service_pending = bool(pending_service_calls.pop(vin, False)) if vin else False
+        # pending_service_calls maps VIN to the user-supplied wake timeout
+        # in seconds. Presence in the dict means "service call pending"; the
+        # value is forwarded to _execute_post_then_get for the wake budget.
+        service_timeout = pending_service_calls.pop(vin, None) if vin else None
+        service_pending = service_timeout is not None
         decision = decide(
             CycleSnapshot(
                 now=dt_util.now(),
@@ -586,7 +612,12 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
 
         # Phase 2: enact the /status decision.
         if vin:
-            await _enact_decision(vehicle, vin, state, decision)
+            wake_timeout_s = (
+                service_timeout
+                if service_timeout is not None
+                else STRATEGY_DEFAULT_WAKE_TIMEOUT_S
+            )
+            await _enact_decision(vehicle, vin, state, decision, wake_timeout_s)
 
         if vin:
             _persist_status_for_cache(vehicle, vin)
@@ -873,7 +904,15 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                 "toyota.refresh_vehicle_status called with no device target"
             )
             return
-        _LOGGER.info("toyota.refresh_vehicle_status invoked for devices=%s", device_ids)
+        # Pull the user-supplied wake-poll budget. services.yaml constrains
+        # this to 10..180 with a default of 60; we mirror that default here
+        # in case the call somehow arrives without the field.
+        timeout_seconds = int(call.data.get(ATTR_TIMEOUT_SECONDS, 60))
+        _LOGGER.info(
+            "toyota.refresh_vehicle_status invoked for devices=%s (timeout=%ds)",
+            device_ids,
+            timeout_seconds,
+        )
         per_entry_vins = _resolve_devices_to_vins_per_entry(hass, device_ids)
         for entry_id, vins in per_entry_vins.items():
             entry_diag = hass.data[DOMAIN].get(f"{entry_id}_diag")
@@ -881,7 +920,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                 continue
             pending = entry_diag.setdefault("pending_service_calls", {})
             for vin in vins:
-                pending[vin] = True
+                pending[vin] = timeout_seconds
             coord = hass.data[DOMAIN].get(entry_id)
             if coord is not None:
                 # Schedule an immediate refresh; the strategy will read the

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -204,21 +204,40 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
             is_cached=True,
         )
 
+    async def _call_tagged(endpoint_name: str, vin: str | None, coro):
+        """Await a pytoyoda call, tagging any exception with the endpoint
+        name. Lets us see per-endpoint 429 distribution in HA's log:
+        \"Toyota 429 on week_summary for vin=...012600\". Needed to
+        interpret the inter-call spacing sweep - if one endpoint 429s
+        disproportionately, spacing alone won't fix it and we pivot."""
+        try:
+            return await coro
+        except BaseException as ex:
+            code = _error_code(ex)
+            vin_tail = f"...{vin[-6:]}" if vin else "<no-vin>"
+            _LOGGER.warning(
+                "Toyota %s on %s for vin=%s", code, endpoint_name, vin_tail
+            )
+            raise
+
     async def _refresh_one_vehicle(vehicle: Vehicle) -> VehicleData:
         """Fetch one vehicle's full data. Does NOT catch exceptions; caller
-        decides retain-vs-propagate policy based on config toggle."""
-        await vehicle.update()
+        decides retain-vs-propagate policy based on config toggle. Each
+        pytoyoda call is tagged via _call_tagged so per-endpoint failure
+        distribution is visible in the log."""
+        vin = vehicle.vin
+        await _call_tagged("vehicle.update", vin, vehicle.update())
         statistics: StatisticsData | None = None
-        if vehicle.vin is not None:
+        if vin is not None:
             # Serialised to avoid Toyota burst rate-limit. Firing these four
             # summary calls in an asyncio.gather within the same event-loop
             # tick reliably trips a 429 with {"description": "Unauthorized"}
             # response bodies. See pytoyoda/ha_toyota#282.
             statistics = StatisticsData(
-                day=await vehicle.get_current_day_summary(),
-                week=await vehicle.get_current_week_summary(),
-                month=await vehicle.get_current_month_summary(),
-                year=await vehicle.get_current_year_summary(),
+                day=await _call_tagged("day_summary", vin, vehicle.get_current_day_summary()),
+                week=await _call_tagged("week_summary", vin, vehicle.get_current_week_summary()),
+                month=await _call_tagged("month_summary", vin, vehicle.get_current_month_summary()),
+                year=await _call_tagged("year_summary", vin, vehicle.get_current_year_summary()),
             )
         now = dt_util.now()
         # NB: do NOT update last_fetch_time_per_vin here. We need commit

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -124,19 +124,18 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
                         )
 
                         if vehicle.vin is not None:
-                            # Use parallel request to get car statistics.
-                            driving_statistics = await asyncio.gather(
-                                vehicle.get_current_day_summary(),
-                                vehicle.get_current_week_summary(),
-                                vehicle.get_current_month_summary(),
-                                vehicle.get_current_year_summary(),
-                            )
-
+                            # Serialised to avoid Toyota burst rate-limit.
+                            # Toyota's API gateway throttles on bursts of
+                            # near-simultaneous requests; firing these four
+                            # summary calls in an asyncio.gather within the
+                            # same event-loop tick reliably trips a 429 with
+                            # {"description": "Unauthorized"} response
+                            # bodies. See pytoyoda/ha_toyota#282.
                             vehicle_data["statistics"] = StatisticsData(
-                                day=driving_statistics[0],
-                                week=driving_statistics[1],
-                                month=driving_statistics[2],
-                                year=driving_statistics[3],
+                                day=await vehicle.get_current_day_summary(),
+                                week=await vehicle.get_current_week_summary(),
+                                month=await vehicle.get_current_month_summary(),
+                                year=await vehicle.get_current_year_summary(),
                             )
 
                         vehicle_informations.append(vehicle_data)

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 
 import asyncio
 import asyncio.exceptions as asyncioexceptions
+import contextlib
 import logging
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, TypedDict, TypeVar
 
 import httpcore
 import httpx
@@ -20,13 +21,40 @@ from loguru import logger
 from pydantic import ValidationError
 
 from .const import (
+    CONF_AUTO_DISABLED_STATUS_REFRESH,
     CONF_BRAND,
+    CONF_ENABLE_STATUS_REFRESH,
+    CONF_FAILED_WAKE_THRESHOLD,
+    CONF_IDLE_WAKE_HOURS,
+    CONF_MAX_CACHE_AGE_MINUTES,
     CONF_METRIC_VALUES,
+    CONF_POLLING_INTERVAL_MINUTES,
+    CONF_POST_COUNT_PER_STOP,
     CONF_RETAIN_ON_TRANSIENT_FAILURE,
+    DEFAULT_AUTO_DISABLED_STATUS_REFRESH,
+    DEFAULT_ENABLE_STATUS_REFRESH,
+    DEFAULT_FAILED_WAKE_THRESHOLD,
+    DEFAULT_IDLE_WAKE_HOURS,
+    DEFAULT_MAX_CACHE_AGE_MINUTES,
+    DEFAULT_POLLING_INTERVAL_MINUTES,
+    DEFAULT_POST_COUNT_PER_STOP,
     DEFAULT_RETAIN_ON_TRANSIENT_FAILURE,
     DOMAIN,
     PLATFORMS,
     STARTUP_MESSAGE,
+)
+from .refresh_strategy import (
+    CycleSnapshot,
+    RefreshAction,
+    RefreshDecision,
+    RefreshTrigger,
+    StrategyOptions,
+    VinState,
+    decide,
+    on_occurrence_advanced,
+    on_post_layer1_failure,
+    on_post_layer1_success,
+    on_wake_failed,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -60,10 +88,14 @@ from pytoyoda.exceptions import (  # noqa: E402
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
     from homeassistant.config_entries import ConfigEntry
-    from homeassistant.core import HomeAssistant
+    from homeassistant.core import HomeAssistant, ServiceCall
     from pytoyoda.models.summary import Summary
     from pytoyoda.models.vehicle import Vehicle
+
+_T = TypeVar("_T")
 
 
 class StatisticsData(TypedDict):
@@ -148,6 +180,28 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
     retain_on_transient: bool = entry.options.get(
         CONF_RETAIN_ON_TRANSIENT_FAILURE, DEFAULT_RETAIN_ON_TRANSIENT_FAILURE
     )
+    # Smart-refresh strategy options. See refresh_strategy.py for the design.
+    enable_status_refresh: bool = entry.options.get(
+        CONF_ENABLE_STATUS_REFRESH, DEFAULT_ENABLE_STATUS_REFRESH
+    )
+    auto_disabled_status_refresh: bool = entry.options.get(
+        CONF_AUTO_DISABLED_STATUS_REFRESH, DEFAULT_AUTO_DISABLED_STATUS_REFRESH
+    )
+    idle_wake_hours: int = entry.options.get(
+        CONF_IDLE_WAKE_HOURS, DEFAULT_IDLE_WAKE_HOURS
+    )
+    failed_wake_threshold: int = entry.options.get(
+        CONF_FAILED_WAKE_THRESHOLD, DEFAULT_FAILED_WAKE_THRESHOLD
+    )
+    max_cache_age_minutes: int = entry.options.get(
+        CONF_MAX_CACHE_AGE_MINUTES, DEFAULT_MAX_CACHE_AGE_MINUTES
+    )
+    polling_interval_minutes: int = entry.options.get(
+        CONF_POLLING_INTERVAL_MINUTES, DEFAULT_POLLING_INTERVAL_MINUTES
+    )
+    post_count_per_stop: int = entry.options.get(
+        CONF_POST_COUNT_PER_STOP, DEFAULT_POST_COUNT_PER_STOP
+    )
     # Persist per-VIN state in hass.data so it survives config entry reload
     # (options flow triggers a reload, which would otherwise recreate these as
     # empty and wipe both the retain cache and the diag sensor history). Scoped
@@ -164,9 +218,51 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
             "last_error_per_vin": {},
         },
     )
+    # Defensive setdefault for new keys: existing entries from Phase 1 have only
+    # the original three. Each new key auto-created on first cycle for any
+    # encountered VIN; declared here at bucket level for clarity.
+    for new_key in (
+        "last_status_occurrence_date_per_vin",
+        "last_status_fetch_at_per_vin",
+        "last_post_attempt_at_per_vin",
+        "last_odometer_km_per_vin",
+        "was_moving_last_cycle_per_vin",
+        "consecutive_failed_wakes_per_vin",
+        "consecutive_post_rejections_per_vin",
+        "soft_disabled_per_vin",
+        "remaining_post_cycles_per_vin",
+        "last_status_refresh_state_per_vin",
+        "last_status_refresh_trigger_per_vin",
+        # Parsed RemoteStatusResponseModel from the most recent successful
+        # /status fetch (GET_ONLY OR POST_THEN_GET). Re-injected into the
+        # Vehicle's _endpoint_data on SERVE_FROM_CACHE cycles, since each
+        # coordinator cycle gets a fresh Vehicle from get_vehicles() with
+        # empty _endpoint_data. Without this, lock/door/window/hood sensors
+        # flip back to "unknown" between Toyota fetches.
+        "last_status_response_per_vin",
+    ):
+        diag_bucket.setdefault(new_key, {})
+    # Pending service-call requests, keyed by VIN. The service handler sets a
+    # value here and reload-triggers the coordinator; the next cycle picks it
+    # up via the strategy's user_service_call_pending input.
+    pending_service_calls: dict[str, bool] = diag_bucket.setdefault(
+        "pending_service_calls", {}
+    )
     last_good_per_vin: dict[str, VehicleData] = diag_bucket["last_good_per_vin"]
-    last_fetch_time_per_vin: dict[str, datetime] = diag_bucket["last_fetch_time_per_vin"]
-    last_error_per_vin: dict[str, tuple[datetime, str]] = diag_bucket["last_error_per_vin"]
+    last_fetch_time_per_vin: dict[str, datetime] = diag_bucket[
+        "last_fetch_time_per_vin"
+    ]
+    last_error_per_vin: dict[str, tuple[datetime, str]] = diag_bucket[
+        "last_error_per_vin"
+    ]
+
+    exception_code_map: list[tuple[tuple[type[BaseException], ...], str]] = [
+        ((httpx.ConnectTimeout, httpcore.ConnectTimeout), "connect timeout"),
+        ((httpx.ReadTimeout, asyncioexceptions.TimeoutError), "read timeout"),
+        ((asyncioexceptions.CancelledError,), "cancelled"),
+        ((ToyotaApiError,), "api error"),
+        ((ToyotaLoginError,), "login error"),
+    ]
 
     def _error_code(exc: BaseException) -> str:
         """Derive a short error-code string for the last_error sensor."""
@@ -176,22 +272,17 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
         for code in ("429", "500", "502", "503", "504"):
             if f"Request Failed. {code}," in msg:
                 return f"HTTP {code}"
-        if isinstance(exc, (httpx.ConnectTimeout, httpcore.ConnectTimeout)):
-            return "connect timeout"
-        if isinstance(exc, (httpx.ReadTimeout, asyncioexceptions.TimeoutError)):
-            return "read timeout"
-        if isinstance(exc, asyncioexceptions.CancelledError):
-            return "cancelled"
-        if isinstance(exc, ToyotaApiError):
-            return "api error"
-        if isinstance(exc, ToyotaLoginError):
-            return "login error"
+        for exc_types, label in exception_code_map:
+            if isinstance(exc, exc_types):
+                return label
         return type(exc).__name__
 
     def _build_vehicle_data_from_cache(vin: str) -> VehicleData:
-        """Return a copy of the last-good VehicleData for a vin, with
-        refreshed error/timestamp fields. The Vehicle object itself is
-        the cached one, so all downstream sensors see the last values."""
+        """Return a copy of the last-good VehicleData for a vin.
+
+        Refreshes error/timestamp fields. The Vehicle object itself is the
+        cached one, so all downstream sensors see the last good values.
+        """
         cached = last_good_per_vin[vin]
         err = last_error_per_vin.get(vin)
         return VehicleData(
@@ -204,29 +295,321 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
             is_cached=True,
         )
 
-    async def _call_tagged(endpoint_name: str, vin: str | None, coro):
-        """Await a pytoyoda call, tagging any exception with the endpoint
-        name. Lets us see per-endpoint 429 distribution in HA's log:
-        \"Toyota 429 on week_summary for vin=...012600\". Needed to
-        interpret the inter-call spacing sweep - if one endpoint 429s
-        disproportionately, spacing alone won't fix it and we pivot."""
+    async def _call_tagged(
+        endpoint_name: str, vin: str | None, coro: Awaitable[_T]
+    ) -> _T:
+        """Await a pytoyoda call, tagging any exception with the endpoint name.
+
+        Lets us see per-endpoint 429 distribution in the HA log, e.g.
+        ``Toyota 429 on week_summary for vin=...012600``. Needed to interpret
+        the inter-call spacing sweep - if one endpoint 429s disproportionately,
+        spacing alone won't fix it and we pivot.
+        """
         try:
             return await coro
         except BaseException as ex:
             code = _error_code(ex)
             vin_tail = f"...{vin[-6:]}" if vin else "<no-vin>"
-            _LOGGER.warning(
-                "Toyota %s on %s for vin=%s", code, endpoint_name, vin_tail
-            )
+            _LOGGER.warning("Toyota %s on %s for vin=%s", code, endpoint_name, vin_tail)
             raise
 
+    def _build_vin_state(vin: str) -> VinState:
+        """Read the per-VIN diag dicts into a VinState snapshot for decide()."""
+        return VinState(
+            last_odometer_km=diag_bucket["last_odometer_km_per_vin"].get(vin),
+            was_moving_last_cycle=diag_bucket["was_moving_last_cycle_per_vin"].get(
+                vin, False
+            ),
+            last_status_occurrence_date=diag_bucket[
+                "last_status_occurrence_date_per_vin"
+            ].get(vin),
+            last_status_fetch_at=diag_bucket["last_status_fetch_at_per_vin"].get(vin),
+            last_post_attempt_at=diag_bucket["last_post_attempt_at_per_vin"].get(vin),
+            consecutive_failed_wakes=diag_bucket[
+                "consecutive_failed_wakes_per_vin"
+            ].get(vin, 0),
+            consecutive_post_rejections=diag_bucket[
+                "consecutive_post_rejections_per_vin"
+            ].get(vin, 0),
+            soft_disabled=diag_bucket["soft_disabled_per_vin"].get(vin, False),
+            remaining_post_cycles=diag_bucket["remaining_post_cycles_per_vin"].get(
+                vin, 0
+            ),
+            has_cached_response=vin in last_good_per_vin,
+        )
+
+    def _persist_vin_state(vin: str, state: VinState) -> None:
+        """Mirror VinState back into the diag bucket dicts."""
+        diag_bucket["last_odometer_km_per_vin"][vin] = state.last_odometer_km
+        diag_bucket["was_moving_last_cycle_per_vin"][vin] = state.was_moving_last_cycle
+        diag_bucket["last_status_occurrence_date_per_vin"][vin] = (
+            state.last_status_occurrence_date
+        )
+        diag_bucket["last_status_fetch_at_per_vin"][vin] = state.last_status_fetch_at
+        diag_bucket["last_post_attempt_at_per_vin"][vin] = state.last_post_attempt_at
+        diag_bucket["consecutive_failed_wakes_per_vin"][vin] = (
+            state.consecutive_failed_wakes
+        )
+        diag_bucket["consecutive_post_rejections_per_vin"][vin] = (
+            state.consecutive_post_rejections
+        )
+        diag_bucket["soft_disabled_per_vin"][vin] = state.soft_disabled
+        diag_bucket["remaining_post_cycles_per_vin"][vin] = state.remaining_post_cycles
+
+    def _strategy_options() -> StrategyOptions:
+        return StrategyOptions(
+            enable_status_refresh=enable_status_refresh,
+            auto_disabled_status_refresh=auto_disabled_status_refresh,
+            idle_wake_hours=idle_wake_hours,
+            failed_wake_threshold=failed_wake_threshold,
+            max_cache_age_minutes=max_cache_age_minutes,
+            post_count_per_stop=post_count_per_stop,
+        )
+
+    async def _execute_post_then_get(
+        vehicle: Vehicle, vin: str, state: VinState
+    ) -> None:
+        """Issue POST /refresh-status, then poll GET /status until cache advances.
+
+        Polls until ``occurrence_date`` advances or a 25-second budget expires.
+        Mutates state in place per the caller contract in refresh_strategy.py.
+        Pytoyoda's controller already retries 429/5xx with exponential backoff,
+        so this loop only iterates if the gateway returned 200 with a stale
+        occurrence_date (legitimate "POST accepted but cache not yet warm").
+        """
+        opts = _strategy_options()
+        post_response = await _call_tagged(
+            "refresh_status", vin, vehicle.refresh_status()
+        )
+        state.last_post_attempt_at = dt_util.now()
+
+        # Layer 1: gateway-level acceptance. payload.return_code "000000" =
+        # accepted; anything else = vehicle does not support refresh-status.
+        # (pytoyoda exposes the field as snake_case via Pydantic Field alias.)
+        payload = getattr(post_response, "payload", None)
+        return_code = getattr(payload, "return_code", None) if payload else None
+
+        if return_code != "000000":
+            should_auto_disable = on_post_layer1_failure(state, opts)
+            _LOGGER.warning(
+                "Toyota refresh-status rejected for vin=...%s (returnCode=%s)",
+                vin[-6:],
+                return_code,
+            )
+            if should_auto_disable:
+                # Persist auto-disable to config_entry.options. Triggers a
+                # listener-driven reload, which is fine - state survives via
+                # diag_bucket.
+                hass.config_entries.async_update_entry(
+                    entry,
+                    options={
+                        **entry.options,
+                        CONF_AUTO_DISABLED_STATUS_REFRESH: True,
+                    },
+                )
+                _LOGGER.warning(
+                    "Toyota auto-disabled smart refresh for vin=...%s after "
+                    "%d consecutive Layer 1 rejections",
+                    vin[-6:],
+                    state.consecutive_post_rejections,
+                )
+            return
+        on_post_layer1_success(state)
+
+        # Layer 2: poll for occurrence_date advancement. 25-second budget
+        # split into ~3 attempts (10s spacing).
+        deadline = dt_util.now() + timedelta(seconds=25)
+        previous_occurrence = state.last_status_occurrence_date
+        while dt_util.now() < deadline:
+            await asyncio.sleep(10)
+            try:
+                await _call_tagged(
+                    "post_status_poll", vin, vehicle.update(only=["status"])
+                )
+            except (
+                ToyotaApiError,
+                httpx.ConnectTimeout,
+                httpcore.ConnectTimeout,
+                asyncioexceptions.TimeoutError,
+                httpx.ReadTimeout,
+            ):
+                # 429s and timeouts here are expected mid-wake; loop again.
+                continue
+            status_data = vehicle._endpoint_data.get("status")  # noqa: SLF001
+            occ = (
+                getattr(getattr(status_data, "payload", None), "occurrence_date", None)
+                if status_data is not None
+                else None
+            )
+            if occ is not None:
+                state.last_status_fetch_at = dt_util.now()
+                if previous_occurrence is None or occ > previous_occurrence:
+                    on_occurrence_advanced(state, occ)
+                    return
+        # Loop expired without advancement.
+        on_wake_failed(state, opts)
+        if state.soft_disabled:
+            _LOGGER.warning(
+                "Toyota soft-disabled status refresh for vin=...%s "
+                "(%d consecutive failed wakes)",
+                vin[-6:],
+                state.consecutive_failed_wakes,
+            )
+
+    async def _enact_decision(
+        vehicle: Vehicle,
+        vin: str,
+        state: VinState,
+        decision: RefreshDecision,
+    ) -> None:
+        """Execute the per-action /status path for one VIN.
+
+        POST_THEN_GET also manages the cycle-based followup counter per the
+        strategy's caller contract: JUST_STOPPED initialises it, followup
+        cycles decrement, SERVICE_CALL / IDLE_WAKE leave it alone.
+        """
+        if decision.action is RefreshAction.POST_THEN_GET:
+            if decision.trigger is RefreshTrigger.JUST_STOPPED:
+                state.remaining_post_cycles = max(0, post_count_per_stop - 1)
+            elif decision.trigger is RefreshTrigger.JUST_STOPPED_FOLLOWUP:
+                state.remaining_post_cycles = max(0, state.remaining_post_cycles - 1)
+            await _execute_post_then_get(vehicle, vin, state)
+        elif decision.action is RefreshAction.GET_ONLY:
+            await _execute_get_only(vehicle, vin, state)
+        elif decision.action is RefreshAction.HARD_DISABLED:
+            # Legacy path: include /status in the standard sweep.
+            with contextlib.suppress(ToyotaApiError, httpx.ReadTimeout):
+                await _call_tagged(
+                    "status_legacy", vin, vehicle.update(only=["status"])
+                )
+        # SERVE_FROM_CACHE: no new fetch; the cached response gets re-injected
+        # via _persist_status_for_cache() below.
+
+    async def _execute_get_only(vehicle: Vehicle, vin: str, state: VinState) -> None:
+        """Issue GET /status only.
+
+        Updates ``state.last_status_fetch_at`` on success and advances the
+        cached occurrence_date if the gateway returned a newer one. Stale-cache
+        429s and read-timeouts are swallowed: the rest of vehicle data is fresh
+        and LockStatus serves from the previous cycle's cached value.
+        """
+        with contextlib.suppress(ToyotaApiError, httpx.ReadTimeout):
+            await _call_tagged("status_only", vin, vehicle.update(only=["status"]))
+            status_data = vehicle._endpoint_data.get("status")  # noqa: SLF001
+            occ = (
+                getattr(
+                    getattr(status_data, "payload", None),
+                    "occurrence_date",
+                    None,
+                )
+                if status_data
+                else None
+            )
+            if occ is not None:
+                state.last_status_fetch_at = dt_util.now()
+                if (
+                    state.last_status_occurrence_date is None
+                    or occ > state.last_status_occurrence_date
+                ):
+                    on_occurrence_advanced(state, occ)
+
+    def _persist_status_for_cache(vehicle: Vehicle, vin: str) -> None:
+        """Mirror this cycle's /status response into the diag-bucket cache.
+
+        If the cycle fetched /status, snapshot it for future SERVE_FROM_CACHE
+        cycles. If it didn't (POST flow skipped, or cache-only this cycle),
+        re-inject the previously cached response into this cycle's fresh
+        Vehicle so lock/door/window sensors keep their last-known values
+        instead of falling to "unknown".
+        """
+        cached_status = vehicle._endpoint_data.get("status")  # noqa: SLF001
+        if cached_status is not None:
+            diag_bucket["last_status_response_per_vin"][vin] = cached_status
+            return
+        cached = diag_bucket["last_status_response_per_vin"].get(vin)
+        if cached is not None:
+            vehicle._endpoint_data["status"] = cached  # noqa: SLF001
+
     async def _refresh_one_vehicle(vehicle: Vehicle) -> VehicleData:
-        """Fetch one vehicle's full data. Does NOT catch exceptions; caller
-        decides retain-vs-propagate policy based on config toggle. Each
-        pytoyoda call is tagged via _call_tagged so per-endpoint failure
-        distribution is visible in the log."""
+        """Fetch one vehicle's full data.
+
+        Does NOT catch exceptions; caller decides retain-vs-propagate policy
+        based on config toggle. Each pytoyoda call is tagged via _call_tagged
+        so per-endpoint failure distribution is visible in the log.
+
+        Smart-refresh strategy (see refresh_strategy.py) gates whether we
+        issue a POST /refresh-status and how we fetch /status. The strategy
+        is consulted AFTER vehicle.update() runs so it can see this cycle's
+        odometer for movement detection.
+        """
         vin = vehicle.vin
-        await _call_tagged("vehicle.update", vin, vehicle.update())
+
+        # Phase 1: fetch every endpoint EXCEPT /status. The strategy decides
+        # the /status path below; calling it inside vehicle.update() risks a
+        # 429+APIGW-403 from a stale cache that we can avoid entirely by
+        # POSTing first OR by serving from cache. Note: vehicle.update() also
+        # populates _endpoint_data["telemetry"], which we read for odometer.
+        await _call_tagged("vehicle.update", vin, vehicle.update(skip=["status"]))
+
+        # Build snapshot for the strategy.
+        current_odometer_km: float | None = None
+        try:
+            telemetry = vehicle._endpoint_data.get("telemetry")  # noqa: SLF001
+            payload = getattr(telemetry, "payload", None)
+            odo_obj = getattr(payload, "odometer", None) if payload else None
+            if odo_obj is not None and odo_obj.value is not None:
+                current_odometer_km = float(odo_obj.value)
+        except (AttributeError, TypeError, ValueError):
+            current_odometer_km = None
+
+        state = _build_vin_state(vin) if vin else VinState()
+        service_pending = bool(pending_service_calls.pop(vin, False)) if vin else False
+        decision = decide(
+            CycleSnapshot(
+                now=dt_util.now(),
+                current_odometer_km=current_odometer_km,
+                state=state,
+                options=_strategy_options(),
+                user_service_call_pending=service_pending,
+            )
+        )
+        _LOGGER.debug(
+            "smart_strategy vin=...%s action=%s trigger=%s service_pending=%s "
+            "soft_disabled=%s pending_keys=%s",
+            (vin or "")[-6:],
+            decision.action.value,
+            decision.trigger.value,
+            service_pending,
+            state.soft_disabled,
+            list(pending_service_calls.keys()),
+        )
+
+        # Phase 2: enact the /status decision.
+        if vin:
+            await _enact_decision(vehicle, vin, state, decision)
+
+        if vin:
+            _persist_status_for_cache(vehicle, vin)
+
+        # Movement / sensor state.
+        car_currently_moving = (
+            state.last_odometer_km is not None
+            and current_odometer_km is not None
+            and current_odometer_km != state.last_odometer_km
+        )
+        state.last_odometer_km = current_odometer_km
+        state.was_moving_last_cycle = car_currently_moving
+
+        # Persist diagnostic state-name for the sensor + commit the rest.
+        if vin:
+            diag_bucket["last_status_refresh_state_per_vin"][vin] = (
+                decision.refresh_state.value
+            )
+            diag_bucket["last_status_refresh_trigger_per_vin"][vin] = (
+                decision.trigger.value
+            )
+            _persist_vin_state(vin, state)
+
         statistics: StatisticsData | None = None
         if vin is not None:
             # Serialised to avoid Toyota burst rate-limit. Firing these four
@@ -234,10 +617,18 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
             # tick reliably trips a 429 with {"description": "Unauthorized"}
             # response bodies. See pytoyoda/ha_toyota#282.
             statistics = StatisticsData(
-                day=await _call_tagged("day_summary", vin, vehicle.get_current_day_summary()),
-                week=await _call_tagged("week_summary", vin, vehicle.get_current_week_summary()),
-                month=await _call_tagged("month_summary", vin, vehicle.get_current_month_summary()),
-                year=await _call_tagged("year_summary", vin, vehicle.get_current_year_summary()),
+                day=await _call_tagged(
+                    "day_summary", vin, vehicle.get_current_day_summary()
+                ),
+                week=await _call_tagged(
+                    "week_summary", vin, vehicle.get_current_week_summary()
+                ),
+                month=await _call_tagged(
+                    "month_summary", vin, vehicle.get_current_month_summary()
+                ),
+                year=await _call_tagged(
+                    "year_summary", vin, vehicle.get_current_year_summary()
+                ),
             )
         now = dt_util.now()
         # NB: do NOT update last_fetch_time_per_vin here. We need commit
@@ -258,8 +649,14 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
             is_cached=False,
         )
 
-    async def async_get_vehicle_data() -> list[VehicleData] | None:  # noqa: C901
-        """Fetch vehicle data from Toyota API, per-car error handling."""
+    async def async_get_vehicle_data() -> list[VehicleData] | None:  # noqa: C901, PLR0912
+        """Fetch vehicle data from Toyota API, per-car error handling.
+
+        Branch count is intentional: each except-arm maps to a distinct
+        recovery policy (retain-cache vs propagate UpdateFailed) for either
+        the fleet-level get_vehicles call or the per-vehicle refresh. Folding
+        them into a helper would obscure the recovery semantics.
+        """
         # Step 1: get the vehicle list. This is account-level; if it fails
         # we have no per-vehicle recovery path, but we CAN serve stale
         # fleet data if any exists.
@@ -285,16 +682,21 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
                 _LOGGER.warning(
                     "Toyota get_vehicles failed (%s); using cached fleet data", code
                 )
-                return [_build_vehicle_data_from_cache(vin) for vin in last_good_per_vin]
-            raise UpdateFailed(f"Toyota get_vehicles failed: {ex}") from ex
-        except ValidationError as ex:
+                return [
+                    _build_vehicle_data_from_cache(vin) for vin in last_good_per_vin
+                ]
+            msg = f"Toyota get_vehicles failed: {ex}"
+            raise UpdateFailed(msg) from ex
+        except ValidationError:
             _LOGGER.exception("Toyota validation error on get_vehicles")
             code = "validation error"
             now = dt_util.now()
             for vin in last_good_per_vin:
                 last_error_per_vin[vin] = (now, code)
             if retain_on_transient and last_good_per_vin:
-                return [_build_vehicle_data_from_cache(vin) for vin in last_good_per_vin]
+                return [
+                    _build_vehicle_data_from_cache(vin) for vin in last_good_per_vin
+                ]
             return None
 
         # Step 2: fetch each vehicle's data independently, so a failure on
@@ -358,7 +760,8 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
             for vd in vehicle_informations
         )
         if not any_served:
-            raise UpdateFailed("Toyota refresh failed for all vehicles")
+            msg = "Toyota refresh failed for all vehicles"
+            raise UpdateFailed(msg)
 
         # Commit per-VIN fetch timestamps now that the refresh has survived
         # all exception paths. This is the only place last_fetch_time_per_vin
@@ -381,7 +784,7 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
         _LOGGER,
         name=DOMAIN,
         update_method=async_get_vehicle_data,
-        update_interval=timedelta(seconds=360),
+        update_interval=timedelta(minutes=polling_interval_minutes),
     )
 
     # Attach the per-VIN diagnostic dicts to the coordinator so sensors can read
@@ -392,6 +795,12 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
     # getattr(coordinator, "_diag_last_fetch_per_vin" / "_diag_last_error_per_vin").
     coordinator._diag_last_fetch_per_vin = last_fetch_time_per_vin  # noqa: SLF001
     coordinator._diag_last_error_per_vin = last_error_per_vin  # noqa: SLF001
+    coordinator._diag_status_occurrence_per_vin = diag_bucket[  # noqa: SLF001
+        "last_status_occurrence_date_per_vin"
+    ]
+    coordinator._diag_status_refresh_state_per_vin = diag_bucket[  # noqa: SLF001
+        "last_status_refresh_state_per_vin"
+    ]
 
     await coordinator.async_config_entry_first_refresh()
 
@@ -401,7 +810,91 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
 
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
+    await _async_register_services(hass)
+
     return True
+
+
+SERVICE_REFRESH_VEHICLE_STATUS = "refresh_vehicle_status"
+ATTR_TIMEOUT_SECONDS = "timeout_seconds"
+
+
+def _resolve_devices_to_vins_per_entry(
+    hass: HomeAssistant, device_ids: list[str]
+) -> dict[str, list[str]]:
+    """Group VINs by config entry id for the requested device targets.
+
+    Devices not registered, devices without a Toyota VIN identifier, and
+    devices whose entry has been unloaded are silently skipped.
+    """
+    from homeassistant.helpers import device_registry as dr  # noqa: PLC0415
+
+    device_reg = dr.async_get(hass)
+    per_entry_vins: dict[str, list[str]] = {}
+    for device_id in device_ids:
+        device = device_reg.async_get(device_id)
+        if device is None:
+            continue
+        vin = next(
+            (
+                identifier
+                for domain, identifier in device.identifiers
+                if domain == DOMAIN
+            ),
+            None,
+        )
+        if not vin:
+            continue
+        for entry_id in device.config_entries:
+            if entry_id in hass.data.get(DOMAIN, {}):
+                per_entry_vins.setdefault(entry_id, []).append(vin)
+    return per_entry_vins
+
+
+async def _async_register_services(hass: HomeAssistant) -> None:
+    """Register the toyota.refresh_vehicle_status service exactly once.
+
+    Service handlers resolve their target devices to VINs via the device
+    registry, set a per-VIN flag in each entry's diag bucket, and trigger
+    an immediate coordinator refresh. The smart strategy then picks up
+    user_service_call_pending=True on the next cycle (within seconds), so
+    the wake POST happens out-of-band of the normal polling cadence.
+    """
+    if hass.services.has_service(DOMAIN, SERVICE_REFRESH_VEHICLE_STATUS):
+        return
+
+    async def _handle_refresh_vehicle_status(call: ServiceCall) -> None:
+        # device_id arrives either as a string (when called with
+        # data={"device_id":...}) or a list (target.device normalization).
+        raw = call.data.get("device_id") or []
+        device_ids: list[str] = [raw] if isinstance(raw, str) else list(raw)
+        if not device_ids:
+            _LOGGER.warning(
+                "toyota.refresh_vehicle_status called with no device target"
+            )
+            return
+        _LOGGER.info("toyota.refresh_vehicle_status invoked for devices=%s", device_ids)
+        per_entry_vins = _resolve_devices_to_vins_per_entry(hass, device_ids)
+        for entry_id, vins in per_entry_vins.items():
+            entry_diag = hass.data[DOMAIN].get(f"{entry_id}_diag")
+            if entry_diag is None:
+                continue
+            pending = entry_diag.setdefault("pending_service_calls", {})
+            for vin in vins:
+                pending[vin] = True
+            coord = hass.data[DOMAIN].get(entry_id)
+            if coord is not None:
+                # Schedule an immediate refresh; the strategy will read the
+                # pending flag and POST. We don't await here because the
+                # refresh chain can take ~25s (poll loop) and HA service
+                # calls block the calling automation by default.
+                hass.async_create_task(coord.async_request_refresh())
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REFRESH_VEHICLE_STATUS,
+        _handle_refresh_vehicle_status,
+    )
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -148,9 +148,25 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
     retain_on_transient: bool = entry.options.get(
         CONF_RETAIN_ON_TRANSIENT_FAILURE, DEFAULT_RETAIN_ON_TRANSIENT_FAILURE
     )
-    last_good_per_vin: dict[str, VehicleData] = {}
-    last_fetch_time_per_vin: dict[str, datetime] = {}
-    last_error_per_vin: dict[str, tuple[datetime, str]] = {}
+    # Persist per-VIN state in hass.data so it survives config entry reload
+    # (options flow triggers a reload, which would otherwise recreate these as
+    # empty and wipe both the retain cache and the diag sensor history). Scoped
+    # per entry_id so multiple Toyota accounts don't collide. Also unblocks the
+    # setup path when the account is actively rate-limited: a fresh reload with
+    # retain=OFF and no cache would loop in setup_retry forever, but with cache
+    # preserved the retain=ON stub path (or the retained fleet) gets us through
+    # first_refresh even under 429 pressure.
+    diag_bucket = hass.data[DOMAIN].setdefault(
+        f"{entry.entry_id}_diag",
+        {
+            "last_good_per_vin": {},
+            "last_fetch_time_per_vin": {},
+            "last_error_per_vin": {},
+        },
+    )
+    last_good_per_vin: dict[str, VehicleData] = diag_bucket["last_good_per_vin"]
+    last_fetch_time_per_vin: dict[str, datetime] = diag_bucket["last_fetch_time_per_vin"]
+    last_error_per_vin: dict[str, tuple[datetime, str]] = diag_bucket["last_error_per_vin"]
 
     def _error_code(exc: BaseException) -> str:
         """Derive a short error-code string for the last_error sensor."""
@@ -205,8 +221,13 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
                 year=await vehicle.get_current_year_summary(),
             )
         now = dt_util.now()
-        if vehicle.vin is not None:
-            last_fetch_time_per_vin[vehicle.vin] = now
+        # NB: do NOT update last_fetch_time_per_vin here. We need commit
+        # semantics matching coordinator.data: if a later vehicle in the loop
+        # fails and we raise UpdateFailed, this vehicle's data is not visible
+        # to sensors - so its fetch timestamp must also not be visible, or
+        # users see the inconsistent "entity unavailable AND last fetch
+        # 3 minutes ago" state. The caller updates last_fetch_time_per_vin
+        # only after the whole refresh has committed.
         err = last_error_per_vin.get(vehicle.vin) if vehicle.vin else None
         return VehicleData(
             data=vehicle,
@@ -285,13 +306,18 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
                     "Toyota refresh failed for vin=...%s (%s)", vin[-6:], code
                 )
                 if retain_on_transient and vin in last_good_per_vin:
+                    # retain=ON + cache available: serve stale cached data.
                     vehicle_informations.append(_build_vehicle_data_from_cache(vin))
-                elif retain_on_transient:
-                    # No cache yet for this vehicle, but we must still emit a
-                    # VehicleData so its entities stay registered and just
-                    # report None state. Skipping would cause IndexError in
-                    # sensor platforms that hold vehicle_index references
-                    # from a previous successful refresh.
+                else:
+                    # retain=OFF OR retain=ON with no cache yet: emit a stub
+                    # VehicleData. The Vehicle object came from get_vehicles()
+                    # so it has identity (vin, alias, device info) but no
+                    # endpoint data because vehicle.update() failed. Data
+                    # sensors read through a ToyotaBaseEntity.available
+                    # override that checks last_successful_fetch, so stubs
+                    # render as unavailable without raising UpdateFailed for
+                    # the whole refresh. Siblings that succeeded this cycle
+                    # keep their fresh data - per-vehicle fault isolation.
                     vehicle_informations.append(
                         VehicleData(
                             data=vehicle,
@@ -303,14 +329,30 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
                             is_cached=False,
                         )
                     )
-                # else (retain disabled): skip this vehicle. In this mode the
-                # coordinator will raise UpdateFailed if the rest of the
-                # fleet also fails, matching upstream behaviour.
 
-        if not vehicle_informations:
-            # Whole fleet failed and nothing cached anywhere. Coordinator
-            # handling: UpdateFailed flips entities to unavailable.
+        # If nothing useful to serve (no fresh fetch anywhere, no cache either),
+        # match upstream behaviour: raise UpdateFailed so the coordinator flips
+        # last_update_success=False and all data sensors become unavailable.
+        # Diag sensors stay visible via their own always_available override.
+        any_served = any(
+            vd.get("is_cached") or vd.get("last_successful_fetch") is not None
+            for vd in vehicle_informations
+        )
+        if not any_served:
             raise UpdateFailed("Toyota refresh failed for all vehicles")
+
+        # Commit per-VIN fetch timestamps now that the refresh has survived
+        # all exception paths. This is the only place last_fetch_time_per_vin
+        # is written to keep it consistent with coordinator.data: both are
+        # updated iff the whole refresh succeeds. Cached entries (from the
+        # retain=ON path) carry None last_successful_fetch and are skipped.
+        for vd in vehicle_informations:
+            if vd.get("is_cached"):
+                continue
+            vin = vd["data"].vin if vd.get("data") else None
+            fetched = vd.get("last_successful_fetch")
+            if vin and fetched is not None:
+                last_fetch_time_per_vin[vin] = fetched
 
         _LOGGER.debug(vehicle_informations)
         return vehicle_informations
@@ -323,13 +365,29 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
         update_interval=timedelta(seconds=360),
     )
 
+    # Attach the per-VIN diagnostic dicts to the coordinator so sensors can read
+    # them even when coordinator.data is stale after UpdateFailed. The dicts are
+    # updated in the refresh function's exception handlers BEFORE UpdateFailed
+    # fires, so they carry the freshest error/timestamp info irrespective of
+    # the retain_on_transient toggle. Diag sensors bind via
+    # getattr(coordinator, "_diag_last_fetch_per_vin" / "_diag_last_error_per_vin").
+    coordinator._diag_last_fetch_per_vin = last_fetch_time_per_vin  # noqa: SLF001
+    coordinator._diag_last_error_per_vin = last_error_per_vin  # noqa: SLF001
+
     await coordinator.async_config_entry_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
     return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the integration when options change so the new toggle takes effect."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/toyota/binary_sensor.py
+++ b/custom_components/toyota/binary_sensor.py
@@ -37,14 +37,26 @@ class ToyotaBinaryEntityDescription(
     attributes_fn: Callable[[Vehicle], dict[str, Any] | None]
 
 
+def _inv_or_none(value: bool | None) -> bool | None:  # noqa: FBT001
+    """Invert a Toyota closed/locked/on boolean, preserving None.
+
+    The HA DOOR/LOCK/WINDOW device classes treat ``on`` as the alarm state
+    (open/unlocked). Toyota's API reports the inverse semantics, so we flip.
+    When the underlying field is None (the car has never reported, or the
+    cache is cold), we return None so the sensor reads as 'unknown' instead
+    of falsely 'open'/'unlocked'. Fix for ha_toyota#87.
+    """
+    return None if value is None else not value
+
+
 HOOD_STATUS_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescription(
     key="hood",
     translation_key="hood",
     icon="mdi:car-door",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.DOOR,
-    value_fn=lambda vehicle: (
-        not getattr(getattr(vehicle.lock_status, "hood", None), "closed", None)
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(getattr(vehicle.lock_status, "hood", None), "closed", None)
     ),
     attributes_fn=lambda vehicle: {
         LAST_UPDATED: getattr(vehicle.lock_status, "last_updated", None),
@@ -57,8 +69,8 @@ FRONT_DRIVER_DOOR_LOCK_STATUS_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescription
     icon="mdi:car-door-lock",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.LOCK,
-    value_fn=lambda vehicle: (
-        not getattr(
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(
             getattr(getattr(vehicle.lock_status, "doors", None), "driver_seat", None),
             "locked",
             None,
@@ -75,8 +87,8 @@ FRONT_DRIVER_DOOR_OPEN_STATUS_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescription
     icon="mdi:car-door",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.DOOR,
-    value_fn=lambda vehicle: (
-        not getattr(
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(
             getattr(getattr(vehicle.lock_status, "doors", None), "driver_seat", None),
             "closed",
             None,
@@ -93,8 +105,8 @@ FRONT_DRIVER_DOOR_WINDOW_STATUS_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescripti
     icon="mdi:car-door",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.WINDOW,
-    value_fn=lambda vehicle: (
-        not getattr(
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(
             getattr(getattr(vehicle.lock_status, "windows", None), "driver_seat", None),
             "closed",
             None,
@@ -111,8 +123,8 @@ FRONT_PASSENGER_DOOR_LOCK_STATUS_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescript
     icon="mdi:car-door-lock",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.LOCK,
-    value_fn=lambda vehicle: (
-        not getattr(
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(
             getattr(
                 getattr(vehicle.lock_status, "doors", None), "passenger_seat", None
             ),
@@ -131,8 +143,8 @@ FRONT_PASSENGER_DOOR_OPEN_STATUS_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescript
     icon="mdi:car-door",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.DOOR,
-    value_fn=lambda vehicle: (
-        not getattr(
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(
             getattr(
                 getattr(vehicle.lock_status, "doors", None), "passenger_seat", None
             ),
@@ -151,8 +163,8 @@ FRONT_PASSENGER_DOOR_WINDOW_STATUS_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescri
     icon="mdi:car-door",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.WINDOW,
-    value_fn=lambda vehicle: (
-        not getattr(
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(
             getattr(
                 getattr(vehicle.lock_status, "windows", None), "passenger_seat", None
             ),
@@ -171,8 +183,8 @@ REAR_DRIVER_DOOR_LOCK_STATUS_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescription(
     icon="mdi:car-door-lock",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.LOCK,
-    value_fn=lambda vehicle: (
-        not getattr(
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(
             getattr(
                 getattr(vehicle.lock_status, "doors", None), "driver_rear_seat", None
             ),
@@ -191,8 +203,8 @@ REAR_DRIVER_DOOR_OPEN_STATUS_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescription(
     icon="mdi:car-door",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.DOOR,
-    value_fn=lambda vehicle: (
-        not getattr(
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(
             getattr(
                 getattr(vehicle.lock_status, "doors", None), "driver_rear_seat", None
             ),
@@ -211,8 +223,8 @@ REAR_DRIVER_DOOR_WINDOW_STATUS_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescriptio
     icon="mdi:car-door",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.WINDOW,
-    value_fn=lambda vehicle: (
-        not getattr(
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(
             getattr(
                 getattr(vehicle.lock_status, "windows", None), "driver_rear_seat", None
             ),
@@ -231,8 +243,8 @@ REAR_PASSENGER_DOOR_LOCK_STATUS_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescripti
     icon="mdi:car-door-lock",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.LOCK,
-    value_fn=lambda vehicle: (
-        not getattr(
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(
             getattr(
                 getattr(vehicle.lock_status, "doors", None), "passenger_rear_seat", None
             ),
@@ -251,8 +263,8 @@ REAR_PASSENGER_DOOR_OPEN_STATUS_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescripti
     icon="mdi:car-door",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.DOOR,
-    value_fn=lambda vehicle: (
-        not getattr(
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(
             getattr(
                 getattr(vehicle.lock_status, "doors", None), "passenger_rear_seat", None
             ),
@@ -271,8 +283,8 @@ REAR_PASSENGER_DOOR_WINDOW_STATUS_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescrip
     icon="mdi:car-door",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.WINDOW,
-    value_fn=lambda vehicle: (
-        not getattr(
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(
             getattr(
                 getattr(vehicle.lock_status, "windows", None),
                 "passenger_rear_seat",
@@ -293,8 +305,8 @@ TRUNK_DOOR_LOCK_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescription(
     icon="mdi:car-door-lock",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.LOCK,
-    value_fn=lambda vehicle: (
-        not getattr(
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(
             getattr(getattr(vehicle.lock_status, "doors", None), "trunk", None),
             "locked",
             None,
@@ -311,8 +323,8 @@ TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescription(
     icon="mdi:car-door",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.WINDOW,
-    value_fn=lambda vehicle: (
-        not getattr(
+    value_fn=lambda vehicle: _inv_or_none(
+        getattr(
             getattr(getattr(vehicle.lock_status, "doors", None), "trunk", None),
             "closed",
             None,

--- a/custom_components/toyota/button.py
+++ b/custom_components/toyota/button.py
@@ -1,0 +1,72 @@
+"""Per-vehicle refresh-status button.
+
+Wraps the toyota.refresh_vehicle_status service with a one-tap dashboard
+entity. Each vehicle gets one button; pressing it triggers the same wake
+POST + status poll that the service does.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+
+from .const import DOMAIN
+from .entity import ToyotaBaseEntity
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+    from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+    from . import VehicleData
+
+
+REFRESH_BUTTON_DESCRIPTION = ButtonEntityDescription(
+    key="refresh_vehicle_status",
+    translation_key="refresh_vehicle_status",
+    name="Refresh vehicle status",
+    icon="mdi:refresh-circle",
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Toyota button entities."""
+    coordinator: DataUpdateCoordinator[list[VehicleData]] = hass.data[DOMAIN][
+        entry.entry_id
+    ]
+    async_add_entities(
+        ToyotaRefreshStatusButton(
+            coordinator=coordinator,
+            entry_id=entry.entry_id,
+            vehicle_index=index,
+            description=REFRESH_BUTTON_DESCRIPTION,
+        )
+        for index in range(len(coordinator.data))
+    )
+
+
+class ToyotaRefreshStatusButton(ToyotaBaseEntity, ButtonEntity):
+    """One-tap wrapper around toyota.refresh_vehicle_status for one VIN."""
+
+    async def async_press(self) -> None:
+        """Fire toyota.refresh_vehicle_status for this vehicle's device."""
+        from homeassistant.helpers import device_registry as dr  # noqa: PLC0415
+
+        device_reg = dr.async_get(self.hass)
+        device = device_reg.async_get_device(
+            identifiers={(DOMAIN, self.vehicle.vin or "")}
+        )
+        if device is None:
+            return
+        await self.hass.services.async_call(
+            DOMAIN,
+            "refresh_vehicle_status",
+            {"device_id": [device.id]},
+            blocking=False,
+        )

--- a/custom_components/toyota/config_flow.py
+++ b/custom_components/toyota/config_flow.py
@@ -14,7 +14,13 @@ from homeassistant.helpers import selector
 from pytoyoda.client import MyT
 from pytoyoda.exceptions import ToyotaInvalidUsernameError, ToyotaLoginError
 
-from .const import CONF_BRAND, CONF_METRIC_VALUES, DOMAIN
+from .const import (
+    CONF_BRAND,
+    CONF_METRIC_VALUES,
+    CONF_RETAIN_ON_TRANSIENT_FAILURE,
+    DEFAULT_RETAIN_ON_TRANSIENT_FAILURE,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +40,13 @@ class ToyotaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pylint: dis
     """Handle a config flow for Toyota Connected Services."""
 
     VERSION = 1
+
+    @staticmethod
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> "ToyotaOptionsFlow":
+        """Return the options flow handler."""
+        return ToyotaOptionsFlow()
 
     def __init__(self) -> None:
         """Start the toyota custom component config flow."""
@@ -136,3 +149,28 @@ class ToyotaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pylint: dis
         self._metric_values = entry_data[CONF_METRIC_VALUES]
         self._brand = entry_data.get(CONF_BRAND, "toyota")
         return await self.async_step_user()
+
+
+class ToyotaOptionsFlow(config_entries.OptionsFlow):
+    """Handle Toyota Connected Services options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current = self.config_entry.options.get(
+            CONF_RETAIN_ON_TRANSIENT_FAILURE, DEFAULT_RETAIN_ON_TRANSIENT_FAILURE
+        )
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_RETAIN_ON_TRANSIENT_FAILURE, default=current
+                    ): selector.BooleanSelector(),
+                }
+            ),
+        )

--- a/custom_components/toyota/config_flow.py
+++ b/custom_components/toyota/config_flow.py
@@ -15,9 +15,22 @@ from pytoyoda.client import MyT
 from pytoyoda.exceptions import ToyotaInvalidUsernameError, ToyotaLoginError
 
 from .const import (
+    CONF_AUTO_DISABLED_STATUS_REFRESH,
     CONF_BRAND,
+    CONF_ENABLE_STATUS_REFRESH,
+    CONF_FAILED_WAKE_THRESHOLD,
+    CONF_IDLE_WAKE_HOURS,
+    CONF_MAX_CACHE_AGE_MINUTES,
     CONF_METRIC_VALUES,
+    CONF_POLLING_INTERVAL_MINUTES,
+    CONF_POST_COUNT_PER_STOP,
     CONF_RETAIN_ON_TRANSIENT_FAILURE,
+    DEFAULT_ENABLE_STATUS_REFRESH,
+    DEFAULT_FAILED_WAKE_THRESHOLD,
+    DEFAULT_IDLE_WAKE_HOURS,
+    DEFAULT_MAX_CACHE_AGE_MINUTES,
+    DEFAULT_POLLING_INTERVAL_MINUTES,
+    DEFAULT_POST_COUNT_PER_STOP,
     DEFAULT_RETAIN_ON_TRANSIENT_FAILURE,
     DOMAIN,
 )
@@ -43,9 +56,14 @@ class ToyotaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pylint: dis
 
     @staticmethod
     def async_get_options_flow(
-        config_entry: config_entries.ConfigEntry,
+        config_entry: config_entries.ConfigEntry,  # noqa: ARG004
     ) -> "ToyotaOptionsFlow":
-        """Return the options flow handler."""
+        """Return the options flow handler.
+
+        ``config_entry`` is part of HA's options-flow signature contract; we
+        don't read it because the flow gets the entry via ``self.config_entry``
+        once instantiated.
+        """
         return ToyotaOptionsFlow()
 
     def __init__(self) -> None:
@@ -159,18 +177,93 @@ class ToyotaOptionsFlow(config_entries.OptionsFlow):
     ) -> FlowResult:
         """Manage the options."""
         if user_input is not None:
+            # Side-effect: re-enabling smart refresh clears the auto-disable
+            # flag. The user took explicit action to override the auto-disable
+            # decision, so we trust them.
+            previous_enable = self.config_entry.options.get(
+                CONF_ENABLE_STATUS_REFRESH, DEFAULT_ENABLE_STATUS_REFRESH
+            )
+            new_enable = user_input.get(
+                CONF_ENABLE_STATUS_REFRESH, DEFAULT_ENABLE_STATUS_REFRESH
+            )
+            if previous_enable is False and new_enable is True:
+                user_input[CONF_AUTO_DISABLED_STATUS_REFRESH] = False
             return self.async_create_entry(title="", data=user_input)
 
-        current = self.config_entry.options.get(
-            CONF_RETAIN_ON_TRANSIENT_FAILURE, DEFAULT_RETAIN_ON_TRANSIENT_FAILURE
-        )
+        opts = self.config_entry.options
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_RETAIN_ON_TRANSIENT_FAILURE, default=current
+                        CONF_POLLING_INTERVAL_MINUTES,
+                        default=opts.get(
+                            CONF_POLLING_INTERVAL_MINUTES,
+                            DEFAULT_POLLING_INTERVAL_MINUTES,
+                        ),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=5, max=60, step=1, mode=selector.NumberSelectorMode.BOX
+                        )
+                    ),
+                    vol.Required(
+                        CONF_RETAIN_ON_TRANSIENT_FAILURE,
+                        default=opts.get(
+                            CONF_RETAIN_ON_TRANSIENT_FAILURE,
+                            DEFAULT_RETAIN_ON_TRANSIENT_FAILURE,
+                        ),
                     ): selector.BooleanSelector(),
+                    vol.Required(
+                        CONF_ENABLE_STATUS_REFRESH,
+                        default=opts.get(
+                            CONF_ENABLE_STATUS_REFRESH,
+                            DEFAULT_ENABLE_STATUS_REFRESH,
+                        ),
+                    ): selector.BooleanSelector(),
+                    vol.Required(
+                        CONF_IDLE_WAKE_HOURS,
+                        default=opts.get(CONF_IDLE_WAKE_HOURS, DEFAULT_IDLE_WAKE_HOURS),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=0, max=72, step=1, mode=selector.NumberSelectorMode.BOX
+                        )
+                    ),
+                    vol.Required(
+                        CONF_FAILED_WAKE_THRESHOLD,
+                        default=opts.get(
+                            CONF_FAILED_WAKE_THRESHOLD,
+                            DEFAULT_FAILED_WAKE_THRESHOLD,
+                        ),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=1, max=10, step=1, mode=selector.NumberSelectorMode.BOX
+                        )
+                    ),
+                    vol.Required(
+                        CONF_MAX_CACHE_AGE_MINUTES,
+                        default=opts.get(
+                            CONF_MAX_CACHE_AGE_MINUTES,
+                            DEFAULT_MAX_CACHE_AGE_MINUTES,
+                        ),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=5,
+                            max=180,
+                            step=5,
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
+                    vol.Required(
+                        CONF_POST_COUNT_PER_STOP,
+                        default=opts.get(
+                            CONF_POST_COUNT_PER_STOP,
+                            DEFAULT_POST_COUNT_PER_STOP,
+                        ),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=1, max=5, step=1, mode=selector.NumberSelectorMode.BOX
+                        )
+                    ),
                 }
             ),
         )

--- a/custom_components/toyota/const.py
+++ b/custom_components/toyota/const.py
@@ -5,6 +5,7 @@ from homeassistant.const import Platform
 # PLATFORMS SUPPORTED
 PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.DEVICE_TRACKER,
     Platform.SENSOR,
     Platform.CLIMATE,
@@ -24,6 +25,37 @@ CONF_METRIC_VALUES = "use_metric_values"
 # flipping entities to unavailable. Off by default for backward compatibility.
 CONF_RETAIN_ON_TRANSIENT_FAILURE = "retain_on_transient_failure"
 DEFAULT_RETAIN_ON_TRANSIENT_FAILURE = False
+
+# Smart status refresh strategy. POSTs /v1/global/remote/refresh-status to
+# wake the car's modem before reading /status, mimicking the Toyota mobile
+# app's two-stage protocol. Reduces stuck-stale lock/door state and 429s.
+# See rate-limit-remediation-plan.md Addendum 4.
+CONF_ENABLE_STATUS_REFRESH = "enable_status_refresh"
+DEFAULT_ENABLE_STATUS_REFRESH = True
+# Set automatically when the gateway repeatedly rejects the POST (vehicle
+# does not support refresh-status). Cleared when user toggles
+# CONF_ENABLE_STATUS_REFRESH OFF then ON. Hidden in the UI.
+CONF_AUTO_DISABLED_STATUS_REFRESH = "auto_disabled_status_refresh"
+DEFAULT_AUTO_DISABLED_STATUS_REFRESH = False
+CONF_IDLE_WAKE_HOURS = "idle_wake_hours"
+# Hours between idle-wake POSTs. 0 disables the feature entirely (off by
+# default); 1-72 = wake every N hours when the car has not moved. Combines
+# what was previously a separate boolean toggle plus a sub-interval.
+DEFAULT_IDLE_WAKE_HOURS = 0
+CONF_FAILED_WAKE_THRESHOLD = "failed_wake_threshold"
+DEFAULT_FAILED_WAKE_THRESHOLD = 3
+CONF_MAX_CACHE_AGE_MINUTES = "max_cache_age_minutes"
+DEFAULT_MAX_CACHE_AGE_MINUTES = 30
+CONF_POLLING_INTERVAL_MINUTES = "polling_interval_minutes"
+DEFAULT_POLLING_INTERVAL_MINUTES = 6
+# How many wake POSTs to fire when a stop event is detected. Cycle-count based
+# (one POST per cycle), independent of polling interval. 1 = single POST on
+# the just-stopped cycle. 2 (default) = an additional POST on the next cycle,
+# which typically catches state the user changes shortly after stopping
+# (locking the doors, opening the trunk). Those post-park events trigger
+# fresh modem reports; the followup POST's poll loop picks them up.
+CONF_POST_COUNT_PER_STOP = "post_count_per_stop"
+DEFAULT_POST_COUNT_PER_STOP = 2
 
 # DEFAULTS
 DEFAULT_LOCALE = "en-gb"

--- a/custom_components/toyota/const.py
+++ b/custom_components/toyota/const.py
@@ -19,6 +19,11 @@ ISSUES_URL = "https://github.com/pytoyoda/ha_toyota/issues"
 CONF_BRAND = "Brand"
 CONF_BRAND_MAPPING = {"T": "Toyota", "L": "Lexus"}
 CONF_METRIC_VALUES = "use_metric_values"
+# When True, per-vehicle cached data is returned on transient coordinator
+# failures (Toyota 429, connection timeouts, read timeouts) instead of
+# flipping entities to unavailable. Off by default for backward compatibility.
+CONF_RETAIN_ON_TRANSIENT_FAILURE = "retain_on_transient_failure"
+DEFAULT_RETAIN_ON_TRANSIENT_FAILURE = False
 
 # DEFAULTS
 DEFAULT_LOCALE = "en-gb"

--- a/custom_components/toyota/entity.py
+++ b/custom_components/toyota/entity.py
@@ -58,15 +58,18 @@ class ToyotaBaseEntity(CoordinatorEntity):
 
     @property
     def available(self) -> bool:
-        """Availability: coordinator must be healthy AND this vehicle's data
-        must be either fresh (non-None last_successful_fetch) or a retain-cache
+        """Per-vehicle availability with fault isolation.
+
+        The coordinator must be healthy AND this vehicle's data must be
+        either fresh (non-None ``last_successful_fetch``) or a retain-cache
         entry. Stubs (refresh failed for this vehicle specifically, no cache
         to serve) read as unavailable even when the coordinator itself
         succeeded because some sibling vehicle DID refresh fine. This is
         per-vehicle fault isolation: a 429 on one car does not hide the other
         car's data. ToyotaCoordinatorStateSensor (diagnostic sensors)
         overrides this back to True - those must stay visible exactly when
-        their vehicle fails, to explain why."""
+        their vehicle fails, to explain why.
+        """
         if not super().available:
             return False
         try:

--- a/custom_components/toyota/entity.py
+++ b/custom_components/toyota/entity.py
@@ -56,6 +56,25 @@ class ToyotaBaseEntity(CoordinatorEntity):
             else "Unknown",
         )
 
+    @property
+    def available(self) -> bool:
+        """Availability: coordinator must be healthy AND this vehicle's data
+        must be either fresh (non-None last_successful_fetch) or a retain-cache
+        entry. Stubs (refresh failed for this vehicle specifically, no cache
+        to serve) read as unavailable even when the coordinator itself
+        succeeded because some sibling vehicle DID refresh fine. This is
+        per-vehicle fault isolation: a 429 on one car does not hide the other
+        car's data. ToyotaCoordinatorStateSensor (diagnostic sensors)
+        overrides this back to True - those must stay visible exactly when
+        their vehicle fails, to explain why."""
+        if not super().available:
+            return False
+        try:
+            vd = self.coordinator.data[self.index]
+        except (IndexError, TypeError):
+            return False
+        return vd.get("is_cached") or vd.get("last_successful_fetch") is not None
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/custom_components/toyota/manifest.json
+++ b/custom_components/toyota/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/pytoyoda/ha_toyota",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pytoyoda/ha_toyota/issues",
-  "requirements": ["pytoyoda>=5.0.0,<6.0", "arrow"],
+  "requirements": ["pytoyoda>=5.1.0,<6.0", "arrow"],
   "version": "v2.2.2"
 }

--- a/custom_components/toyota/refresh_strategy.py
+++ b/custom_components/toyota/refresh_strategy.py
@@ -1,0 +1,365 @@
+"""Smart status-refresh decision tree (per-VIN, per coordinator cycle).
+
+Pure function module: takes a state snapshot, returns a RefreshDecision
+describing what the coordinator should do this cycle for one VIN. No
+hass / no I/O / no time.now() - all "now" values are passed in. This makes
+the decision tree deterministically unit-testable without booting hass.
+
+Spec source: rate-limit-remediation-plan.md Addendum 4 (2026-04-25).
+Background: we discovered on 2026-04-24 that Toyota's `/v1/global/remote/status`
+returns 429+APIGW-403 ("Unauthorized") when its server-side cache is empty
+or stale, NOT because we're hitting a rate limit. The cache is populated
+by either auto-reports from a transmitting (driving) car, or by an explicit
+POST `/refresh-status` (a "wake" request). The Toyota Android app issues
+the POST before reading status. This module decides when WE should issue
+that POST, balancing fresh data against 12V-battery / cellular costs.
+
+Caller contract (the coordinator's `_refresh_one_vehicle`):
+
+After enacting a RefreshDecision, the caller MUST update VinState as
+follows. The decision tree itself is side-effect-free; mutation happens
+in the caller so retain-vs-propagate failure semantics stay there.
+
+  - Always at end of cycle:
+      state.last_odometer_km = snapshot.current_odometer_km
+      state.was_moving_last_cycle = (movement detected this cycle)
+
+  - When action == POST_THEN_GET:
+      state.last_post_attempt_at = now
+      if decision.trigger is JUST_STOPPED:
+          state.remaining_post_cycles = options.post_count_per_stop - 1
+      elif decision.trigger is JUST_STOPPED_FOLLOWUP:
+          state.remaining_post_cycles = max(0, state.remaining_post_cycles - 1)
+      # SERVICE_CALL / IDLE_WAKE do not touch remaining_post_cycles.
+      On Layer 1 result: call on_post_layer1_failure() or
+        on_post_layer1_success().
+      On poll-loop outcome:
+        - occurrence advanced: call on_occurrence_advanced(state, new_occ)
+        - timed out: call on_wake_failed(state, options)
+
+  - When action == GET_ONLY:
+      On 200: state.last_status_fetch_at = now
+              if occurrence advanced: call on_occurrence_advanced(...)
+      On 429: leave state alone.
+
+  - When action == SERVE_FROM_CACHE:
+      No state mutation needed. Caller serves cached LockStatus.
+
+  - When action == HARD_DISABLED:
+      Caller falls through to legacy path (bare vehicle.update()).
+      No new state mutations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import StrEnum
+
+# Number of consecutive Layer 1 (gateway-rejected) wake POSTs that auto-disables
+# refresh-status for the entire config entry. Per remediation-plan Addendum 4.
+_AUTO_DISABLE_REJECTION_THRESHOLD = 2
+
+
+class RefreshAction(StrEnum):
+    """What this cycle should do for one VIN."""
+
+    POST_THEN_GET = "post_then_get"
+    """Issue POST /refresh-status, then poll /status until occurrence_date
+    advances or the in-cycle timeout expires."""
+
+    GET_ONLY = "get_only"
+    """Issue GET /status only (cache may already be populated by an external
+    source or a moving car's auto-reports)."""
+
+    SERVE_FROM_CACHE = "serve_from_cache"
+    """Skip both the POST and the GET; serve LockStatus from last_good_response.
+    Other endpoints already refreshed elsewhere this cycle."""
+
+    HARD_DISABLED = "hard_disabled"
+    """User toggle off, OR auto-disabled because the vehicle doesn't support
+    refresh-status. Coordinator should fall through to legacy refresh path
+    (single vehicle.update() call, serve cached LockStatus on stale)."""
+
+
+class RefreshState(StrEnum):
+    """Steady-state value of the diagnostic sensor `<alias>_status_refresh_state`.
+
+    These are user-facing translation keys; do not rename without updating
+    translations/en.json + every other locale.
+    """
+
+    ACTIVE = "active"
+    SOFT_DISABLED_UNREACHABLE = "soft_disabled_unreachable"
+    HARD_DISABLED_AUTO = "hard_disabled_auto"
+    HARD_DISABLED_USER = "hard_disabled_user"
+
+
+class RefreshTrigger(StrEnum):
+    """Why the strategy chose to act (debug logging + diagnostic sensor)."""
+
+    NONE = "none"
+    SERVICE_CALL = "service_call"
+    JUST_STOPPED = "just_stopped"
+    JUST_STOPPED_FOLLOWUP = "just_stopped_followup"
+    CURRENTLY_MOVING = "currently_moving"
+    IDLE_WAKE = "idle_wake"
+    CACHE_STALE = "cache_stale"
+    CACHE_EMPTY = "cache_empty"
+
+
+# ----------------------------------------------------------------------------
+# Inputs (snapshot of state at the start of one VIN's cycle).
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class StrategyOptions:
+    """Mirror of the user-configurable options from config_entry.options."""
+
+    enable_status_refresh: bool = True
+    auto_disabled_status_refresh: bool = False
+    # Hours between idle-wake POSTs. 0 disables the feature; >0 fires a wake
+    # POST every N hours when the car has not moved.
+    idle_wake_hours: int = 0
+    failed_wake_threshold: int = 3
+    max_cache_age_minutes: int = 30
+    # How many wake POSTs to fire per stop event. The first POST goes out the
+    # cycle just_stopped is detected; the remaining N-1 POSTs go out on the
+    # immediately following cycles. Cycle-count based (not wall-clock) so that
+    # the behaviour is consistent regardless of polling interval.
+    post_count_per_stop: int = 2
+
+
+@dataclass
+class VinState:
+    """Per-VIN runtime state. Stored in hass.data[DOMAIN][f"{entry_id}_diag"]."""
+
+    # Movement / odometer tracking. None on first cycle ever for this VIN.
+    last_odometer_km: float | None = None
+    was_moving_last_cycle: bool = False
+
+    # Cache freshness (server-side, mirrored on our end).
+    last_status_occurrence_date: datetime | None = None
+    last_status_fetch_at: datetime | None = None  # OUR last GET that returned 200
+
+    # Wake bookkeeping.
+    last_post_attempt_at: datetime | None = None
+    consecutive_failed_wakes: int = 0
+    consecutive_post_rejections: int = 0
+    soft_disabled: bool = False
+    # Remaining POST cycles for the in-progress stop event. Set to
+    # post_count_per_stop - 1 by the caller when JUST_STOPPED fires; decremented
+    # by the caller after each followup POST. > 0 -> next cycle fires another
+    # POST trigger=just_stopped_followup. Clears naturally to 0.
+    remaining_post_cycles: int = 0
+
+    # Whether last_good_response is non-None - used to short-circuit
+    # SERVE_FROM_CACHE when there's nothing to serve.
+    has_cached_response: bool = False
+
+
+@dataclass
+class CycleSnapshot:
+    """Everything the strategy needs to decide one cycle for one VIN."""
+
+    now: datetime
+    current_odometer_km: float | None  # from telemetry (this cycle, post-update)
+    state: VinState
+    options: StrategyOptions
+    user_service_call_pending: bool = False
+
+
+# ----------------------------------------------------------------------------
+# Outputs.
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class RefreshDecision:
+    """The strategy's verdict for one cycle."""
+
+    action: RefreshAction
+    trigger: RefreshTrigger
+    refresh_state: RefreshState
+
+
+# ----------------------------------------------------------------------------
+# The decision tree. ~50 lines of straight-line logic. Side-effect-free; the
+# caller is responsible for applying mutations to VinState based on what
+# actually happens after the decision is enacted.
+# ----------------------------------------------------------------------------
+
+
+def _hard_disable_decision(opts: StrategyOptions) -> RefreshDecision | None:
+    """Return a HARD_DISABLED decision if either disable flag is set, else None."""
+    if not opts.enable_status_refresh:
+        return RefreshDecision(
+            action=RefreshAction.HARD_DISABLED,
+            trigger=RefreshTrigger.NONE,
+            refresh_state=RefreshState.HARD_DISABLED_USER,
+        )
+    if opts.auto_disabled_status_refresh:
+        return RefreshDecision(
+            action=RefreshAction.HARD_DISABLED,
+            trigger=RefreshTrigger.NONE,
+            refresh_state=RefreshState.HARD_DISABLED_AUTO,
+        )
+    return None
+
+
+def _resolve_post_trigger(
+    snapshot: CycleSnapshot,
+    *,
+    car_just_stopped: bool,
+    car_currently_moving: bool,
+) -> tuple[bool, RefreshTrigger]:
+    """Pick whether this cycle should POST and the diagnostic trigger label.
+
+    Order of precedence is significant: explicit user requests beat in-flight
+    stop followups beat fresh stop detection beat idle-wake. Movement is the
+    fallback "informational" trigger when none of the above fire.
+    """
+    state = snapshot.state
+    opts = snapshot.options
+    now = snapshot.now
+
+    if snapshot.user_service_call_pending:
+        return True, RefreshTrigger.SERVICE_CALL
+    if state.remaining_post_cycles > 0:
+        return True, RefreshTrigger.JUST_STOPPED_FOLLOWUP
+    if car_just_stopped:
+        return True, RefreshTrigger.JUST_STOPPED
+    if car_currently_moving:
+        return False, RefreshTrigger.CURRENTLY_MOVING
+    if opts.idle_wake_hours > 0 and (
+        state.last_post_attempt_at is None
+        or (now - state.last_post_attempt_at) >= timedelta(hours=opts.idle_wake_hours)
+    ):
+        return True, RefreshTrigger.IDLE_WAKE
+    return False, RefreshTrigger.NONE
+
+
+def decide(snapshot: CycleSnapshot) -> RefreshDecision:
+    """Pure decision: what should this cycle do for this VIN?
+
+    Caller (the coordinator) is responsible for executing the action and
+    updating state based on outcomes.
+    """
+    opts = snapshot.options
+    state = snapshot.state
+    now = snapshot.now
+
+    hard = _hard_disable_decision(opts)
+    if hard is not None:
+        return hard
+
+    # Movement state from telemetry (already fetched by the caller's
+    # vehicle.update() this cycle).
+    car_currently_moving = (
+        state.last_odometer_km is not None
+        and snapshot.current_odometer_km is not None
+        and snapshot.current_odometer_km != state.last_odometer_km
+    )
+    car_just_stopped = state.was_moving_last_cycle and not car_currently_moving
+
+    should_post, trigger = _resolve_post_trigger(
+        snapshot,
+        car_just_stopped=car_just_stopped,
+        car_currently_moving=car_currently_moving,
+    )
+
+    # Soft-disable suppresses POST (still allows GET so we can detect external
+    # cache repopulation) but keeps the trigger label for diagnostics.
+    soft_disabled = state.soft_disabled
+    if soft_disabled:
+        should_post = False
+
+    # Decide if a GET is needed even when no POST.
+    cache_age = (
+        (now - state.last_status_fetch_at)
+        if state.last_status_fetch_at
+        else timedelta(days=365)
+    )
+    cache_stale = cache_age > timedelta(minutes=opts.max_cache_age_minutes)
+    cache_empty = state.last_status_occurrence_date is None
+
+    # NB: car_currently_moving is intentionally NOT in this OR-chain. During a
+    # drive we can serve the pre-drive lock state from cache; refreshing only
+    # when actually stale avoids ~40 useless /status calls on a long trip.
+    should_get = car_just_stopped or should_post or cache_stale or cache_empty
+
+    refresh_state = (
+        RefreshState.SOFT_DISABLED_UNREACHABLE if soft_disabled else RefreshState.ACTIVE
+    )
+
+    if should_post:
+        return RefreshDecision(
+            action=RefreshAction.POST_THEN_GET,
+            trigger=trigger,
+            refresh_state=refresh_state,
+        )
+
+    if should_get:
+        if trigger is RefreshTrigger.NONE:
+            if cache_empty:
+                trigger = RefreshTrigger.CACHE_EMPTY
+            elif cache_stale:
+                trigger = RefreshTrigger.CACHE_STALE
+        return RefreshDecision(
+            action=RefreshAction.GET_ONLY,
+            trigger=trigger,
+            refresh_state=refresh_state,
+        )
+
+    return RefreshDecision(
+        action=RefreshAction.SERVE_FROM_CACHE,
+        trigger=trigger,
+        refresh_state=refresh_state,
+    )
+
+
+# ----------------------------------------------------------------------------
+# State-mutation helpers. Caller invokes these after enacting a decision and
+# observing the outcome. Keeping them in this module so the strategy and its
+# state-machine bookkeeping live together.
+# ----------------------------------------------------------------------------
+
+
+def on_post_layer1_failure(state: VinState, _options: StrategyOptions) -> bool:
+    """Record a non-000000 returnCode from POST.
+
+    Returns True if this should trigger auto-disable (hard-disable) at the
+    config-entry level. Per Addendum 4 step 11b: 2 consecutive rejections ->
+    auto-disable. The options arg is reserved for a future user-tunable
+    threshold; currently unused.
+    """
+    state.consecutive_post_rejections += 1
+    return state.consecutive_post_rejections >= _AUTO_DISABLE_REJECTION_THRESHOLD
+
+
+def on_post_layer1_success(state: VinState) -> None:
+    """Reset the rejection counter; POST was accepted by the gateway."""
+    state.consecutive_post_rejections = 0
+
+
+def on_wake_failed(state: VinState, options: StrategyOptions) -> None:
+    """Record that POST polling expired without occurrence_date advancement.
+
+    Per Addendum 4 step 11c: at threshold, soft-disable this VIN.
+    Caller should clear just_stopped_followup_due_at; that's separate state.
+    """
+    state.consecutive_failed_wakes += 1
+    if state.consecutive_failed_wakes >= options.failed_wake_threshold:
+        state.soft_disabled = True
+
+
+def on_occurrence_advanced(state: VinState, new_occurrence: datetime) -> None:
+    """Cache successfully advanced.
+
+    Either POST polling succeeded, OR an external source warmed the cache.
+    Clears soft-disable per Addendum 4 step 14.
+    """
+    state.last_status_occurrence_date = new_occurrence
+    state.consecutive_failed_wakes = 0
+    state.soft_disabled = False

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -457,6 +457,7 @@ class ToyotaSensor(ToyotaBaseEntity, SensorEntity):
 
 LAST_SUCCESSFUL_FETCH_ENTITY_DESCRIPTION = SensorEntityDescription(
     key="last_successful_fetch",
+    translation_key="last_successful_fetch",
     name="Last successful fetch",
     icon="mdi:clock-check-outline",
     device_class=SensorDeviceClass.TIMESTAMP,
@@ -464,6 +465,7 @@ LAST_SUCCESSFUL_FETCH_ENTITY_DESCRIPTION = SensorEntityDescription(
 )
 LAST_ERROR_TIME_ENTITY_DESCRIPTION = SensorEntityDescription(
     key="last_error_time",
+    translation_key="last_error_time",
     name="Last error",
     icon="mdi:clock-alert-outline",
     device_class=SensorDeviceClass.TIMESTAMP,
@@ -471,6 +473,7 @@ LAST_ERROR_TIME_ENTITY_DESCRIPTION = SensorEntityDescription(
 )
 LAST_ERROR_CODE_ENTITY_DESCRIPTION = SensorEntityDescription(
     key="last_error_code",
+    translation_key="last_error_code",
     name="Last error code",
     icon="mdi:alert-outline",
     entity_category=EntityCategory.DIAGNOSTIC,
@@ -478,40 +481,57 @@ LAST_ERROR_CODE_ENTITY_DESCRIPTION = SensorEntityDescription(
 
 
 class ToyotaCoordinatorStateSensor(ToyotaBaseEntity, SensorEntity):
-    """Sensor whose value comes from a key on VehicleData rather than
-    from the Vehicle object. Used for the three observability sensors
-    (last_successful_fetch, last_error_time, last_error_code) that
-    describe the fetch itself, not the vehicle's state."""
+    """Sensor whose value comes from the coordinator's per-VIN diagnostic
+    dicts rather than from coordinator.data. Used for the three observability
+    sensors (last_successful_fetch, last_error_time, last_error_code) that
+    describe the fetch itself, not the vehicle's state.
 
-    # ToyotaBaseEntity sets _attr_has_entity_name = True. With that, HA
-    # expects translation_key to resolve the per-entity name component,
-    # and without it entity_id collapses to just the device slug
-    # (sensor.rav4, sensor.rav4_2, etc). We opt out for these diagnostic
-    # sensors so _attr_name acts as the full entity name, and entity_id
-    # is the slug of "<vehicle alias> <sensor name>".
-    _attr_has_entity_name = False
+    Two overrides are in play:
 
-    def __init__(
-        self,
-        coordinator: DataUpdateCoordinator[list[VehicleData]],
-        entry_id: str,
-        vehicle_index: int,
-        description: SensorEntityDescription,
-    ) -> None:
-        """Initialise the coordinator-state sensor."""
-        super().__init__(coordinator, entry_id, vehicle_index, description)
-        alias = self.vehicle.alias or self.vehicle.vin or "Toyota"
-        self._attr_name = f"{alias} {description.name}"
+    1. `available` is forced True. These sensors exist to explain WHY the
+       data sensors went unavailable, so they themselves must never go
+       unavailable. HA's DataUpdateCoordinator drives CoordinatorEntity's
+       availability off `last_update_success`, which flips False on
+       UpdateFailed; we explicitly unbind from that signal.
+
+    2. `native_value` reads from the per-VIN dicts attached to the
+       coordinator (`_diag_last_fetch_per_vin`, `_diag_last_error_per_vin`)
+       instead of `coordinator.data`. The reason: with retain_on_transient=False
+       and a full-fleet 429, `async_get_vehicle_data` raises UpdateFailed
+       before appending any VehicleData, so coordinator.data stays frozen
+       at the last SUCCESSFUL refresh (where the error fields were None).
+       Reading from the per-VIN dicts instead means error info appears as
+       soon as it's known, regardless of retain toggle or UpdateFailed.
+    """
+
+    _DIAG_KEY_MAP = {
+        "last_successful_fetch": ("_diag_last_fetch_per_vin", None),
+        "last_error_time": ("_diag_last_error_per_vin", 0),
+        "last_error_code": ("_diag_last_error_per_vin", 1),
+    }
+
+    @property
+    def available(self) -> bool:
+        """Diagnostic sensors are always considered available."""
+        return True
 
     @property
     def native_value(self) -> StateType:
-        """Return the value for this sensor from the coordinator data dict."""
-        try:
-            return self.coordinator.data[self.index].get(
-                self.entity_description.key
-            )
-        except (IndexError, KeyError, TypeError):
+        """Return the value from the coordinator's per-VIN diagnostic dicts."""
+        vin = getattr(self.vehicle, "vin", None)
+        if not vin:
             return None
+        key = self.entity_description.key
+        attr_name, tuple_idx = self._DIAG_KEY_MAP.get(key, (None, None))
+        if attr_name is None:
+            return None
+        per_vin = getattr(self.coordinator, attr_name, None)
+        if per_vin is None:
+            return None
+        value = per_vin.get(vin)
+        if value is None:
+            return None
+        return value if tuple_idx is None else value[tuple_idx]
 
 
 class ToyotaStatisticsSensor(ToyotaBaseEntity, SensorEntity):
@@ -537,12 +557,16 @@ class ToyotaStatisticsSensor(ToyotaBaseEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
+        if self.statistics is None:
+            return None
         data = self.statistics[self.period]
         return round(data.distance, 1) if data and data.distance else None
 
     @property
     def extra_state_attributes(self) -> dict | None:
         """Return the state attributes."""
+        if self.statistics is None:
+            return None
         data = self.statistics[self.period]
         return (
             format_statistics_attributes(data, self.vehicle._vehicle_info)  # noqa : SLF001

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -478,13 +478,36 @@ LAST_ERROR_CODE_ENTITY_DESCRIPTION = SensorEntityDescription(
     icon="mdi:alert-outline",
     entity_category=EntityCategory.DIAGNOSTIC,
 )
+STATUS_LAST_REPORTED_ENTITY_DESCRIPTION = SensorEntityDescription(
+    key="status_last_reported",
+    translation_key="status_last_reported",
+    name="Status last reported by car",
+    icon="mdi:car-clock",
+    device_class=SensorDeviceClass.TIMESTAMP,
+    entity_category=EntityCategory.DIAGNOSTIC,
+)
+STATUS_REFRESH_STATE_ENTITY_DESCRIPTION = SensorEntityDescription(
+    key="status_refresh_state",
+    translation_key="status_refresh_state",
+    name="Status refresh state",
+    icon="mdi:refresh-auto",
+    device_class=SensorDeviceClass.ENUM,
+    options=[
+        "active",
+        "soft_disabled_unreachable",
+        "hard_disabled_auto",
+        "hard_disabled_user",
+    ],
+    entity_category=EntityCategory.DIAGNOSTIC,
+)
 
 
 class ToyotaCoordinatorStateSensor(ToyotaBaseEntity, SensorEntity):
-    """Sensor whose value comes from the coordinator's per-VIN diagnostic
-    dicts rather than from coordinator.data. Used for the three observability
-    sensors (last_successful_fetch, last_error_time, last_error_code) that
-    describe the fetch itself, not the vehicle's state.
+    """Sensor backed by per-VIN diagnostic dicts on the coordinator.
+
+    Used for observability sensors (last_successful_fetch, last_error_time,
+    last_error_code, status_last_reported, status_refresh_state) that
+    describe the fetch itself or the strategy's state, not the vehicle.
 
     Two overrides are in play:
 
@@ -496,18 +519,20 @@ class ToyotaCoordinatorStateSensor(ToyotaBaseEntity, SensorEntity):
 
     2. `native_value` reads from the per-VIN dicts attached to the
        coordinator (`_diag_last_fetch_per_vin`, `_diag_last_error_per_vin`)
-       instead of `coordinator.data`. The reason: with retain_on_transient=False
-       and a full-fleet 429, `async_get_vehicle_data` raises UpdateFailed
-       before appending any VehicleData, so coordinator.data stays frozen
-       at the last SUCCESSFUL refresh (where the error fields were None).
-       Reading from the per-VIN dicts instead means error info appears as
-       soon as it's known, regardless of retain toggle or UpdateFailed.
+       instead of `coordinator.data`. With retain_on_transient=False and a
+       full-fleet 429, `async_get_vehicle_data` raises UpdateFailed before
+       appending any VehicleData, so coordinator.data stays frozen at the
+       last SUCCESSFUL refresh (where the error fields were None). Reading
+       from the per-VIN dicts instead means error info appears as soon as
+       it's known, regardless of retain toggle or UpdateFailed.
     """
 
-    _DIAG_KEY_MAP = {
+    _DIAG_KEY_MAP: ClassVar[dict[str, tuple[str, int | None]]] = {
         "last_successful_fetch": ("_diag_last_fetch_per_vin", None),
         "last_error_time": ("_diag_last_error_per_vin", 0),
         "last_error_code": ("_diag_last_error_per_vin", 1),
+        "status_last_reported": ("_diag_status_occurrence_per_vin", None),
+        "status_refresh_state": ("_diag_status_refresh_state_per_vin", None),
     }
 
     @property
@@ -623,18 +648,20 @@ async def async_setup_entry(
 
         # Add coordinator-state observability sensors (always on, not
         # gated by CONF_RETAIN_ON_TRANSIENT_FAILURE; they are read-only).
-        for desc in (
-            LAST_SUCCESSFUL_FETCH_ENTITY_DESCRIPTION,
-            LAST_ERROR_TIME_ENTITY_DESCRIPTION,
-            LAST_ERROR_CODE_ENTITY_DESCRIPTION,
-        ):
-            sensors.append(
-                ToyotaCoordinatorStateSensor(
-                    coordinator=coordinator,
-                    entry_id=entry.entry_id,
-                    vehicle_index=index,
-                    description=desc,
-                )
+        sensors.extend(
+            ToyotaCoordinatorStateSensor(
+                coordinator=coordinator,
+                entry_id=entry.entry_id,
+                vehicle_index=index,
+                description=desc,
             )
+            for desc in (
+                LAST_SUCCESSFUL_FETCH_ENTITY_DESCRIPTION,
+                LAST_ERROR_TIME_ENTITY_DESCRIPTION,
+                LAST_ERROR_CODE_ENTITY_DESCRIPTION,
+                STATUS_LAST_REPORTED_ENTITY_DESCRIPTION,
+                STATUS_REFRESH_STATE_ENTITY_DESCRIPTION,
+            )
+        )
 
     async_add_devices(sensors)

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -455,6 +455,65 @@ class ToyotaSensor(ToyotaBaseEntity, SensorEntity):
         return self.description.attributes_fn(self.vehicle)
 
 
+LAST_SUCCESSFUL_FETCH_ENTITY_DESCRIPTION = SensorEntityDescription(
+    key="last_successful_fetch",
+    name="Last successful fetch",
+    icon="mdi:clock-check-outline",
+    device_class=SensorDeviceClass.TIMESTAMP,
+    entity_category=EntityCategory.DIAGNOSTIC,
+)
+LAST_ERROR_TIME_ENTITY_DESCRIPTION = SensorEntityDescription(
+    key="last_error_time",
+    name="Last error",
+    icon="mdi:clock-alert-outline",
+    device_class=SensorDeviceClass.TIMESTAMP,
+    entity_category=EntityCategory.DIAGNOSTIC,
+)
+LAST_ERROR_CODE_ENTITY_DESCRIPTION = SensorEntityDescription(
+    key="last_error_code",
+    name="Last error code",
+    icon="mdi:alert-outline",
+    entity_category=EntityCategory.DIAGNOSTIC,
+)
+
+
+class ToyotaCoordinatorStateSensor(ToyotaBaseEntity, SensorEntity):
+    """Sensor whose value comes from a key on VehicleData rather than
+    from the Vehicle object. Used for the three observability sensors
+    (last_successful_fetch, last_error_time, last_error_code) that
+    describe the fetch itself, not the vehicle's state."""
+
+    # ToyotaBaseEntity sets _attr_has_entity_name = True. With that, HA
+    # expects translation_key to resolve the per-entity name component,
+    # and without it entity_id collapses to just the device slug
+    # (sensor.rav4, sensor.rav4_2, etc). We opt out for these diagnostic
+    # sensors so _attr_name acts as the full entity name, and entity_id
+    # is the slug of "<vehicle alias> <sensor name>".
+    _attr_has_entity_name = False
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[list[VehicleData]],
+        entry_id: str,
+        vehicle_index: int,
+        description: SensorEntityDescription,
+    ) -> None:
+        """Initialise the coordinator-state sensor."""
+        super().__init__(coordinator, entry_id, vehicle_index, description)
+        alias = self.vehicle.alias or self.vehicle.vin or "Toyota"
+        self._attr_name = f"{alias} {description.name}"
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the value for this sensor from the coordinator data dict."""
+        try:
+            return self.coordinator.data[self.index].get(
+                self.entity_description.key
+            )
+        except (IndexError, KeyError, TypeError):
+            return None
+
+
 class ToyotaStatisticsSensor(ToyotaBaseEntity, SensorEntity):
     """Representation of a Toyota statistics sensor."""
 
@@ -537,5 +596,21 @@ async def async_setup_entry(
             if config["description"].key.startswith("current_")
             and config["capability_check"](vehicle)
         )
+
+        # Add coordinator-state observability sensors (always on, not
+        # gated by CONF_RETAIN_ON_TRANSIENT_FAILURE; they are read-only).
+        for desc in (
+            LAST_SUCCESSFUL_FETCH_ENTITY_DESCRIPTION,
+            LAST_ERROR_TIME_ENTITY_DESCRIPTION,
+            LAST_ERROR_CODE_ENTITY_DESCRIPTION,
+        ):
+            sensors.append(
+                ToyotaCoordinatorStateSensor(
+                    coordinator=coordinator,
+                    entry_id=entry.entry_id,
+                    vehicle_index=index,
+                    description=desc,
+                )
+            )
 
     async_add_devices(sensors)

--- a/custom_components/toyota/services.yaml
+++ b/custom_components/toyota/services.yaml
@@ -1,0 +1,25 @@
+refresh_vehicle_status:
+  name: Refresh vehicle status
+  description: >
+    Wakes the vehicle's cellular modem and fetches fresh door, lock, window
+    and trunk state. Use sparingly - each call uses a small amount of
+    cellular airtime and 12V battery. Recommended for use after returning
+    home from a drive when you want the lock state to be visible quickly,
+    or wired to an automation that triggers on a specific event.
+  target:
+    device:
+      integration: toyota
+  fields:
+    timeout_seconds:
+      name: Timeout
+      description: >
+        How long to wait for the car to transmit fresh data after the wake
+        request. Longer values give silent (deeply parked) cars more time
+        to respond, but block the service call until the timeout expires.
+      default: 60
+      selector:
+        number:
+          min: 10
+          max: 180
+          step: 5
+          unit_of_measurement: s

--- a/custom_components/toyota/services.yaml
+++ b/custom_components/toyota/services.yaml
@@ -6,10 +6,14 @@ refresh_vehicle_status:
     cellular airtime and 12V battery. Recommended for use after returning
     home from a drive when you want the lock state to be visible quickly,
     or wired to an automation that triggers on a specific event.
-  target:
-    device:
-      integration: toyota
   fields:
+    device_id:
+      name: Vehicle
+      description: The Toyota vehicle whose modem to wake.
+      required: true
+      selector:
+        device:
+          integration: toyota
     timeout_seconds:
       name: Timeout
       description: >

--- a/custom_components/toyota/translations/en.json
+++ b/custom_components/toyota/translations/en.json
@@ -22,10 +22,22 @@
       "init": {
         "title": "Toyota Connected Services options",
         "data": {
-          "retain_on_transient_failure": "Retain last good data on transient failures (recommended)"
+          "polling_interval_minutes": "Polling interval (minutes)",
+          "retain_on_transient_failure": "Retain last good data on transient failures (recommended)",
+          "enable_status_refresh": "Refresh vehicle status remotely (recommended)",
+          "idle_wake_hours": "Wake idle vehicle every N hours (0 = disabled)",
+          "failed_wake_threshold": "Mark unreachable after N failed wakes",
+          "max_cache_age_minutes": "Refresh status cache if older",
+          "post_count_per_stop": "Wake POSTs per stop event"
         },
         "data_description": {
-          "retain_on_transient_failure": "When enabled, a temporary Toyota API failure (HTTP 429, timeout, connection error) keeps the last successful per-vehicle data in place instead of marking every Toyota entity as unavailable. The new 'Last successful fetch', 'Last error' and 'Last error code' diagnostic sensors show the true state of the integration."
+          "polling_interval_minutes": "How often the integration polls Toyota for fresh data (5-60 minutes; default 6). Lower values may hit rate limits.",
+          "retain_on_transient_failure": "When enabled, a temporary Toyota API failure (HTTP 429, timeout, connection error) keeps the last successful per-vehicle data in place instead of marking every Toyota entity as unavailable. The new 'Last successful fetch', 'Last error' and 'Last error code' diagnostic sensors show the true state of the integration.",
+          "enable_status_refresh": "Toyota's API gateway often returns stuck-stale lock and door state unless the car's modem is woken explicitly. When enabled, the integration sends a wake request before reading status, mimicking the Toyota mobile app. Each wake uses a small amount of cellular airtime and 12V battery; the smart triggers (just-stopped detection, optional idle wake) keep the cost low. Disable for vehicles whose Toyota account does not support refresh-status; the integration auto-disables this for you if it detects unsupported responses. Note: this scope is only the /v1/global/remote/status endpoint (door, window, lock and hood state); other data (odometer, fuel, location, etc.) is fetched every cycle regardless. When this option is OFF, the four options below (idle wake, failed-wake threshold, status cache age, wake POSTs per stop) have no effect.",
+          "idle_wake_hours": "Wake the car periodically even if it has not moved. Useful for cars that sit unused for days where you still want fresh lock state. 0 (default) disables this entirely; 1-72 = wake every N hours. Each wake costs cellular airtime and a small amount of 12 V battery. Note: the wake only refreshes the /v1/global/remote/status endpoint (door, window, lock and hood state). Other data (odometer, fuel, location, etc.) is fetched on every cycle independently and does not need a wake.",
+          "failed_wake_threshold": "If a vehicle stops responding to wake requests this many times in a row, it is marked unreachable per-VIN until it shows any sign of life (driving event, external app refresh, manual service call). Default 3.",
+          "max_cache_age_minutes": "Maximum acceptable age of the cached status data before issuing a fresh GET (5-180 minutes; default 30). Note: this controls only the /v1/global/remote/status endpoint, which carries door, window, lock and hood state. Other data (odometer, fuel, location, etc.) is fetched on every cycle independently.",
+          "post_count_per_stop": "How many wake POSTs to fire when the vehicle is detected as just-stopped, one per coordinator cycle. 1 = single POST. 2 (default) = an additional POST on the next cycle, which typically catches state the user changes shortly after stopping (locking the doors, opening the trunk, etc.) - those events trigger fresh modem reports that the second POST's poll loop picks up. Higher values rarely help and burn 12 V battery."
         }
       }
     }
@@ -118,6 +130,23 @@
       },
       "last_error_code": {
         "name": "Last error code"
+      },
+      "status_last_reported": {
+        "name": "Status last reported by car"
+      },
+      "status_refresh_state": {
+        "name": "Status refresh state",
+        "state": {
+          "active": "Active",
+          "soft_disabled_unreachable": "Unreachable",
+          "hard_disabled_auto": "Disabled (unsupported)",
+          "hard_disabled_user": "Disabled (by user)"
+        }
+      }
+    },
+    "button": {
+      "refresh_vehicle_status": {
+        "name": "Refresh vehicle status"
       }
     },
     "binary_sensor": {

--- a/custom_components/toyota/translations/en.json
+++ b/custom_components/toyota/translations/en.json
@@ -20,8 +20,12 @@
   "options": {
     "step": {
       "init": {
+        "title": "Toyota Connected Services options",
         "data": {
-          "use_liters": "Use liters (L/100 miles) instead of MPG. Only applicable if you car reports data in miles (Imperial unit system)."
+          "retain_on_transient_failure": "Retain last good data on transient failures (recommended)"
+        },
+        "data_description": {
+          "retain_on_transient_failure": "When enabled, a temporary Toyota API failure (HTTP 429, timeout, connection error) keeps the last successful per-vehicle data in place instead of marking every Toyota entity as unavailable. The new 'Last successful fetch', 'Last error' and 'Last error code' diagnostic sensors show the true state of the integration."
         }
       }
     }
@@ -105,6 +109,15 @@
       },
       "current_year_statistics": {
         "name": "Current year statistics"
+      },
+      "last_successful_fetch": {
+        "name": "Last successful fetch"
+      },
+      "last_error_time": {
+        "name": "Last error"
+      },
+      "last_error_code": {
+        "name": "Last error code"
       }
     },
     "binary_sensor": {

--- a/info.md
+++ b/info.md
@@ -18,6 +18,9 @@ You should then perform a reboot and can then reinstall the custom component via
 - See your vin and other details about your car.
 - Daily, weekly, monthly and yearly statistics.
 - Door and door lock sensors, including hood and trunk sensor.
+- Smart status refresh: per-vehicle button + automation service that wakes
+  the car so lock/door/window/hood state always reflects reality.
+- Diagnostic sensors for fetch health and cache freshness.
 - And more...
 
 See [features](https://github.com/DurgNomis-drol/ha_toyota#binary-sensors) section for more details

--- a/tests/test_binary_sensor_null_fix.py
+++ b/tests/test_binary_sensor_null_fix.py
@@ -1,0 +1,63 @@
+"""Regression tests for the ha_toyota#87 null-rendering fix.
+
+Before the fix, `not getattr(getattr(...), 'closed', None)` evaluated to
+`not None` -> True when the field was missing, causing every door/window/
+hood/lock to render as "open" or "unlocked" on first cold cache. After the
+fix, _inv_or_none() preserves None so HA renders "unknown" instead.
+"""
+
+from __future__ import annotations
+
+from custom_components.toyota.binary_sensor import (
+    HOOD_STATUS_ENTITY_DESCRIPTION,
+    _inv_or_none,
+)
+
+
+class _FakeVehicle:
+    """Minimal vehicle stub. Subclasses set lock_status to control fixtures."""
+
+    lock_status = None
+
+
+class _FakeHood:
+    def __init__(self, closed: bool | None) -> None:
+        self.closed = closed
+
+
+class _FakeLockStatus:
+    def __init__(self, hood: _FakeHood | None) -> None:
+        self.hood = hood
+
+
+def test_inv_or_none_preserves_none():
+    assert _inv_or_none(None) is None
+
+
+def test_inv_or_none_inverts_booleans():
+    assert _inv_or_none(True) is False
+    assert _inv_or_none(False) is True
+
+
+def test_hood_value_fn_returns_none_when_lock_status_missing():
+    """Cold cache: vehicle.lock_status is None -> sensor reads as unknown."""
+    vehicle = _FakeVehicle()
+    assert HOOD_STATUS_ENTITY_DESCRIPTION.value_fn(vehicle) is None
+
+
+def test_hood_value_fn_returns_none_when_closed_field_missing():
+    """Partial response: hood object exists but closed field is None."""
+    vehicle = _FakeVehicle()
+    vehicle.lock_status = _FakeLockStatus(hood=_FakeHood(closed=None))
+    assert HOOD_STATUS_ENTITY_DESCRIPTION.value_fn(vehicle) is None
+
+
+def test_hood_value_fn_inverts_closed_bool():
+    """When the field IS populated, render the inverted bool (HA DOOR class
+    treats True as 'open')."""
+    vehicle = _FakeVehicle()
+    vehicle.lock_status = _FakeLockStatus(hood=_FakeHood(closed=True))
+    assert HOOD_STATUS_ENTITY_DESCRIPTION.value_fn(vehicle) is False  # closed -> not-open
+
+    vehicle.lock_status = _FakeLockStatus(hood=_FakeHood(closed=False))
+    assert HOOD_STATUS_ENTITY_DESCRIPTION.value_fn(vehicle) is True  # open

--- a/tests/test_refresh_strategy.py
+++ b/tests/test_refresh_strategy.py
@@ -1,0 +1,352 @@
+"""Unit tests for the smart-refresh decision tree.
+
+The decision tree is a pure function so these tests don't need hass or
+network. Each test sets up a CycleSnapshot, calls decide(), and asserts the
+RefreshDecision is what Addendum 4 prescribes.
+
+Numbering refers to the steps in `rate-limit-remediation-plan.md` Addendum 4.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from custom_components.toyota.refresh_strategy import (
+    CycleSnapshot,
+    RefreshAction,
+    RefreshState,
+    RefreshTrigger,
+    StrategyOptions,
+    VinState,
+    decide,
+    on_occurrence_advanced,
+    on_post_layer1_failure,
+    on_post_layer1_success,
+    on_wake_failed,
+)
+
+
+NOW = datetime(2026, 4, 25, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def _snap(**overrides) -> CycleSnapshot:
+    """Build a CycleSnapshot with safe defaults; overrides patch any field."""
+    state = overrides.pop("state", VinState())
+    options = overrides.pop("options", StrategyOptions())
+    return CycleSnapshot(
+        now=overrides.pop("now", NOW),
+        current_odometer_km=overrides.pop("current_odometer_km", 1000.0),
+        state=state,
+        options=options,
+        user_service_call_pending=overrides.pop("user_service_call_pending", False),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 1: hard-disable paths
+# ---------------------------------------------------------------------------
+
+
+def test_user_disabled_returns_hard_disabled_user():
+    s = _snap(options=StrategyOptions(enable_status_refresh=False))
+    d = decide(s)
+    assert d.action is RefreshAction.HARD_DISABLED
+    assert d.refresh_state is RefreshState.HARD_DISABLED_USER
+
+
+def test_auto_disabled_returns_hard_disabled_auto():
+    s = _snap(
+        options=StrategyOptions(
+            enable_status_refresh=True, auto_disabled_status_refresh=True
+        )
+    )
+    d = decide(s)
+    assert d.action is RefreshAction.HARD_DISABLED
+    assert d.refresh_state is RefreshState.HARD_DISABLED_AUTO
+
+
+# ---------------------------------------------------------------------------
+# Step 4: service-call wins over everything except hard-disable
+# ---------------------------------------------------------------------------
+
+
+def test_service_call_triggers_post(  # noqa: D103
+):
+    s = _snap(user_service_call_pending=True)
+    d = decide(s)
+    assert d.action is RefreshAction.POST_THEN_GET
+    assert d.trigger is RefreshTrigger.SERVICE_CALL
+
+
+# ---------------------------------------------------------------------------
+# just_stopped triggers POST; remaining_post_cycles drives the followup count
+# ---------------------------------------------------------------------------
+
+
+def test_just_stopped_triggers_post():
+    state = VinState(
+        last_odometer_km=1000.0,
+        was_moving_last_cycle=True,
+        has_cached_response=True,
+    )
+    s = _snap(state=state, current_odometer_km=1000.0)
+    d = decide(s)
+    assert d.action is RefreshAction.POST_THEN_GET
+    assert d.trigger is RefreshTrigger.JUST_STOPPED
+
+
+def test_remaining_post_cycles_triggers_followup_post():
+    state = VinState(
+        last_odometer_km=1000.0,
+        was_moving_last_cycle=False,
+        remaining_post_cycles=1,
+        has_cached_response=True,
+    )
+    s = _snap(state=state, current_odometer_km=1000.0)
+    d = decide(s)
+    assert d.action is RefreshAction.POST_THEN_GET
+    assert d.trigger is RefreshTrigger.JUST_STOPPED_FOLLOWUP
+
+
+def test_remaining_post_cycles_zero_means_no_followup():
+    state = VinState(
+        last_odometer_km=1000.0,
+        was_moving_last_cycle=False,
+        remaining_post_cycles=0,
+        last_status_occurrence_date=NOW,
+        last_status_fetch_at=NOW,
+        has_cached_response=True,
+    )
+    s = _snap(state=state, current_odometer_km=1000.0)
+    d = decide(s)
+    assert d.action is RefreshAction.SERVE_FROM_CACHE
+
+
+# ---------------------------------------------------------------------------
+# currently_moving: cache fresh -> SERVE_FROM_CACHE (no /status calls during
+# a long drive). Cache stale -> GET_ONLY (refresh).
+# ---------------------------------------------------------------------------
+
+
+def test_currently_moving_with_fresh_cache_serves_from_cache():
+    state = VinState(
+        last_odometer_km=1000.0,
+        was_moving_last_cycle=True,
+        last_status_occurrence_date=NOW - timedelta(minutes=2),
+        last_status_fetch_at=NOW - timedelta(minutes=2),
+        has_cached_response=True,
+    )
+    s = _snap(state=state, current_odometer_km=1010.0)
+    d = decide(s)
+    assert d.action is RefreshAction.SERVE_FROM_CACHE
+    assert d.trigger is RefreshTrigger.CURRENTLY_MOVING
+
+
+def test_currently_moving_with_stale_cache_does_get():
+    state = VinState(
+        last_odometer_km=1000.0,
+        was_moving_last_cycle=True,
+        last_status_occurrence_date=NOW - timedelta(hours=1),
+        last_status_fetch_at=NOW - timedelta(hours=1),
+        has_cached_response=True,
+    )
+    s = _snap(state=state, current_odometer_km=1010.0)
+    d = decide(s)
+    assert d.action is RefreshAction.GET_ONLY
+    # Trigger may be CURRENTLY_MOVING (set first) or CACHE_STALE (set as
+    # diagnostic fallback when no other trigger fired). Accept either.
+    assert d.trigger in (
+        RefreshTrigger.CURRENTLY_MOVING,
+        RefreshTrigger.CACHE_STALE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 7: idle wake (opt-in)
+# ---------------------------------------------------------------------------
+
+
+def test_idle_wake_zero_hours_means_no_post_when_idle():
+    """idle_wake_hours=0 (default) disables the feature; idle cars don't POST."""
+    state = VinState(
+        last_odometer_km=1000.0,
+        last_status_occurrence_date=NOW - timedelta(minutes=5),
+        last_status_fetch_at=NOW - timedelta(minutes=5),
+        has_cached_response=True,
+    )
+    s = _snap(state=state, current_odometer_km=1000.0)
+    d = decide(s)
+    assert d.action is RefreshAction.SERVE_FROM_CACHE
+
+
+def test_idle_wake_triggers_post_after_interval():
+    state = VinState(
+        last_odometer_km=1000.0,
+        was_moving_last_cycle=False,
+        last_post_attempt_at=NOW - timedelta(hours=13),
+        last_status_occurrence_date=NOW,
+        last_status_fetch_at=NOW,
+        has_cached_response=True,
+    )
+    options = StrategyOptions(idle_wake_hours=12)
+    s = _snap(state=state, options=options, current_odometer_km=1000.0)
+    d = decide(s)
+    assert d.action is RefreshAction.POST_THEN_GET
+    assert d.trigger is RefreshTrigger.IDLE_WAKE
+
+
+def test_idle_wake_within_interval_skips_post():
+    state = VinState(
+        last_odometer_km=1000.0,
+        last_post_attempt_at=NOW - timedelta(hours=2),
+        last_status_occurrence_date=NOW,
+        last_status_fetch_at=NOW,
+        has_cached_response=True,
+    )
+    options = StrategyOptions(idle_wake_hours=12)
+    s = _snap(state=state, options=options, current_odometer_km=1000.0)
+    d = decide(s)
+    assert d.action is RefreshAction.SERVE_FROM_CACHE
+
+
+# ---------------------------------------------------------------------------
+# Step 9: cache stale / empty triggers GET_ONLY
+# ---------------------------------------------------------------------------
+
+
+def test_cache_empty_triggers_get():
+    state = VinState(last_odometer_km=1000.0, has_cached_response=False)
+    s = _snap(state=state, current_odometer_km=1000.0)
+    d = decide(s)
+    assert d.action is RefreshAction.GET_ONLY
+    assert d.trigger is RefreshTrigger.CACHE_EMPTY
+
+
+def test_cache_stale_triggers_get():
+    state = VinState(
+        last_odometer_km=1000.0,
+        last_status_occurrence_date=NOW - timedelta(minutes=45),
+        last_status_fetch_at=NOW - timedelta(minutes=45),
+        has_cached_response=True,
+    )
+    options = StrategyOptions(max_cache_age_minutes=30)
+    s = _snap(state=state, options=options, current_odometer_km=1000.0)
+    d = decide(s)
+    assert d.action is RefreshAction.GET_ONLY
+    assert d.trigger is RefreshTrigger.CACHE_STALE
+
+
+# ---------------------------------------------------------------------------
+# Step 10: soft-disable suppresses POST but allows GET
+# ---------------------------------------------------------------------------
+
+
+def test_soft_disable_suppresses_post_but_allows_get_when_stale():
+    state = VinState(
+        last_odometer_km=1000.0,
+        was_moving_last_cycle=True,
+        soft_disabled=True,
+        has_cached_response=True,
+    )
+    # Just-stopped would normally POST; soft-disable downgrades to GET only
+    # because should_get_status remains True (car_just_stopped path).
+    s = _snap(state=state, current_odometer_km=1000.0)
+    d = decide(s)
+    assert d.action is RefreshAction.GET_ONLY
+    assert d.refresh_state is RefreshState.SOFT_DISABLED_UNREACHABLE
+
+
+# ---------------------------------------------------------------------------
+# Step 13: serve from cache when nothing fired
+# ---------------------------------------------------------------------------
+
+
+def test_idle_fresh_cache_serves_from_cache():
+    """Stationary car, fresh cache, no triggers fired -> skip both."""
+    state = VinState(
+        last_odometer_km=1000.0,
+        was_moving_last_cycle=False,
+        last_status_occurrence_date=NOW - timedelta(minutes=2),
+        last_status_fetch_at=NOW - timedelta(minutes=2),
+        has_cached_response=True,
+    )
+    s = _snap(state=state, current_odometer_km=1000.0)
+    d = decide(s)
+    assert d.action is RefreshAction.SERVE_FROM_CACHE
+
+
+# ---------------------------------------------------------------------------
+# State helpers
+# ---------------------------------------------------------------------------
+
+
+def test_layer1_failure_counter_triggers_auto_disable_after_two():
+    state = VinState()
+    options = StrategyOptions()
+    assert on_post_layer1_failure(state, options) is False
+    assert state.consecutive_post_rejections == 1
+    assert on_post_layer1_failure(state, options) is True  # auto-disable now
+    assert state.consecutive_post_rejections == 2
+
+
+def test_layer1_success_resets_rejection_counter():
+    state = VinState(consecutive_post_rejections=1)
+    on_post_layer1_success(state)
+    assert state.consecutive_post_rejections == 0
+
+
+def test_wake_failed_triggers_soft_disable_at_threshold():
+    state = VinState()
+    options = StrategyOptions(failed_wake_threshold=3)
+    on_wake_failed(state, options)
+    on_wake_failed(state, options)
+    assert state.soft_disabled is False
+    on_wake_failed(state, options)
+    assert state.soft_disabled is True
+    assert state.consecutive_failed_wakes == 3
+
+
+def test_occurrence_advanced_clears_soft_disable():
+    state = VinState(
+        soft_disabled=True,
+        consecutive_failed_wakes=5,
+        last_status_occurrence_date=NOW - timedelta(hours=1),
+    )
+    on_occurrence_advanced(state, NOW)
+    assert state.soft_disabled is False
+    assert state.consecutive_failed_wakes == 0
+    assert state.last_status_occurrence_date == NOW
+
+
+# ---------------------------------------------------------------------------
+# Edge: first cycle ever (no last_odometer_km baseline yet)
+# ---------------------------------------------------------------------------
+
+
+def test_first_cycle_no_movement_inferred():
+    """First cycle: state.last_odometer_km is None. No movement signal possible.
+    Strategy should NOT classify this as "just stopped" (would falsely POST)."""
+    state = VinState(last_odometer_km=None, was_moving_last_cycle=False)
+    s = _snap(state=state, current_odometer_km=1000.0)
+    d = decide(s)
+    # cache_empty is True (last_status_occurrence_date is None default), so GET
+    assert d.action is RefreshAction.GET_ONLY
+    assert d.trigger in (RefreshTrigger.CACHE_EMPTY, RefreshTrigger.CACHE_STALE)
+
+
+def test_no_telemetry_this_cycle_does_not_crash():
+    """Telemetry might be unavailable; current_odometer_km can be None.
+    Strategy must not break."""
+    state = VinState(
+        last_odometer_km=1000.0,
+        last_status_occurrence_date=NOW,
+        last_status_fetch_at=NOW,
+        has_cached_response=True,
+    )
+    s = _snap(state=state, current_odometer_km=None)
+    d = decide(s)
+    # No movement detected (current_odometer_km is None -> not moving).
+    # Cache fresh, no other triggers -> serve from cache.
+    assert d.action is RefreshAction.SERVE_FROM_CACHE


### PR DESCRIPTION
## Summary

Substantial coordinator-side rework to address the long-running cluster of
issues around stuck-stale lock/door state and 429 flood on `/v1/global/remote/status`.
Combined with the companion pytoyoda change, this resolves or materially
mitigates 9 open issues across both repos.

### What the gateway looks like (validated empirically, see linked gist)

Toyota's `/v1/global/remote/status` endpoint reads a **server-side cache**.
The cache is populated by:
1. The vehicle's modem auto-reporting (primarily on park transitions, not
   continuously while driving).
2. An explicit `POST /v1/global/remote/refresh-status` to wake the modem.

A bare `GET` against the gateway has a tendency to return `429+APIGW-403`
("Unauthorized"). When and why this happens is not fully understood - the
errors appear stochastic and don't cleanly correlate with cache freshness
or recent request volume. To read door / window / lock / hood state, the
Toyota Android app issues a two-stage `POST /v1/global/remote/refresh-status`
+ `GET /v1/global/remote/status` whenever the user opens it; separately,
the car's modem appears to send its own auto-report on parking events,
which lands in the gateway cache and shows up on the next `GET /status` as
an advanced `occurrence_date`. The HA integration sits in neither position:
it has no user-opened-app moment to anchor on, and it has no notification
channel for modem reports - it only sees them on the next GET.

The new strategy approximates both signals: it issues the two-stage POST+GET
on a small set of trigger conditions (just-stopped detected via odometer
delta, the configurable followup window, manual service call, optional idle
wake), and otherwise leaves the gateway alone. The strategy is
deliberately restrained to keep the request rate low enough to avoid Toyota
flagging or rate-limiting the account; under defaults a typical commute
results in about two POSTs per stop event, not per cycle.

### Wake-attempt outcomes (terminology used below)

A wake attempt has two outcomes worth distinguishing - they're referenced
by name throughout the rest of the PR:

- **POST `/refresh-status` outcome**: the immediate response from the wake
  call. The gateway returns a `return_code` field. `000000` = "POST
  accepted, modem will be paged". Non-`000000` = "POST rejected" (vehicle
  doesn't support refresh-status, account credentials wrong, etc -
  permanent rather than transient).
- **GET `/status` poll outcome**: did the modem actually wake up. We poll
  GET `/status` after the POST and watch `occurrence_date` advance. If it
  advances within the in-cycle budget (25s), the wake succeeded. If it
  doesn't, the POST was accepted but the modem either didn't respond or
  didn't update the cache - we call this a **failed wake** (POST OK, GET
  poll never sees fresh data).

The auto-disable / soft-disable thresholds below act on these two outcomes
separately.

### What's in this PR

1. **Smart-refresh decision tree** (`refresh_strategy.py`, fully unit-tested):
   per-VIN, per-cycle pure function that picks one of four actions:
   `POST_THEN_GET` (wake + poll), `GET_ONLY` (cache fresh enough), `SERVE_FROM_CACHE`
   (re-inject previous response, no network), `HARD_DISABLED` (fallback to
   legacy bare GET). Triggers include `just_stopped` (odometer-delta-based),
   `just_stopped_followup` (the second wake N cycles after stop, configurable
   via `post_count_per_stop`), `service_call`, `idle_wake`, `cache_stale`,
   `cache_empty`, and `currently_moving`.
2. **Two-stage wake protocol** in the coordinator: POST `/refresh-status`,
   then poll GET `/status` until `occurrence_date` advances or a 25 s budget
   expires. Pytoyoda's controller already retries 429/5xx with backoff, so
   this loop only iterates if the gateway returned 200 with a stale
   occurrence (legitimate "POST accepted but cache not yet warm").
3. **Cache re-injection layer**, gated by the `retain_on_transient_failure`
   options-flow toggle. With retain ON, lock/door/window/hood sensors stay
   populated across `SERVE_FROM_CACHE` cycles by mirroring the previous
   cycle's `/status` payload onto the new `Vehicle` instance. With retain
   OFF (default), a `SERVE_FROM_CACHE` decision still avoids the network
   call, but the sensors render as `unknown` for that cycle.
4. **Per-vehicle fault isolation** (structural, always-on). The coordinator
   fetches each VIN's data inside its own try/except block, so a 429 on one
   car never cascades to siblings - they keep fetching, succeeding, and
   rendering fresh data regardless of the `retain_on_transient_failure`
   setting. The toggle only changes how the *failed* vehicle renders:
   - `retain=ON`: failed vehicle keeps last-good cached data
   - `retain=OFF` (default): failed vehicle's data sensors render as
     `unavailable` (via a `ToyotaBaseEntity.available` override that checks
     `last_successful_fetch`)
5. **Auto-disable + soft-disable** (using the two outcomes from above —
   note the different scopes):
   - **2 consecutive POST rejections** on any VIN (POST `/refresh-status`
     returns non-`000000`) hard-disable refresh-status **for the whole
     config entry**. The rejection counter is tracked per-VIN, but once
     any VIN trips the threshold, the strategy flips a config-entry-level
     `auto_disabled_status_refresh` flag that takes effect across all
     VINs in that entry on the next cycle. Surfaced as `hard_disabled_auto`
     on each VIN's diagnostic sensor. All VINs fall back to legacy bare GET.
     **Lift-off**: the user toggles `enable_status_refresh` OFF then ON in
     the options flow; that transition clears the auto-disable flag.
     There is no automatic recovery and no per-VIN lift. Rationale: a
     non-`000000` return code is a permanent feature-support signal (the
     account, brand, or vehicle generation doesn't allow refresh-status),
     not a transient error - so we trust the gateway and stop trying.
     Edge case: in a mixed fleet where one VIN supports it and one
     doesn't, the supporting VIN loses the automatic wake mechanism too.
     For users in that situation, the `toyota.refresh_vehicle_status`
     service call (per-VIN, fired from an automation on the user's own
     schedule) is available as a workaround.
   - **N consecutive failed wakes** (POST accepted but the GET `/status`
     poll never sees `occurrence_date` advance; `failed_wake_threshold`,
     default 3) soft-disable wake POSTs **for that VIN only** until any
     sign of life clears it (driving event, external app refresh, manual
     service call). Sibling VINs are unaffected. Rationale: failed wakes
     are transient (modem out of coverage, parked in a garage), so we
     pause and try again.
6. **#87 null-render fix**: door / lock / window sensors no longer falsely
   render as `open`/`unlocked` when the underlying field is `None` (cold cache,
   never reported). Old code used `not getattr(...) `; missing -> `not None == True`.
   Replaced with an `_inv_or_none(value)` helper applied to all 15 binary_sensor
   lambdas; missing now renders as `unknown`.
7. **Seven new options-flow settings** to drive everything above (full
   table in the next section). Notably this also **exposes the previously
   hardcoded 6-minute polling interval as a user setting** -
   `polling_interval_minutes`, range 5-60, default 6. Users on accounts
   that prefer a gentler cadence (or who are paying particular attention
   to the 12V battery cost on a rarely-driven car) can now dial it down
   without patching the integration.

### New entities

- **Refresh button**: `button.<alias>_refresh_vehicle_status` - one per
  vehicle, lets the user trigger a wake POST manually. Counts as a
  `service_call` trigger in the strategy so it bypasses the freshness
  heuristics.
- **Refresh state diagnostic** (sensor, per vehicle):
  - `..._status_last_reported_by_car` - timestamp from the **gateway
    cache's `occurrence_date` field**, i.e. when the car's modem last
    talked to Toyota's servers (regardless of whether HA fetched since).
    Goes stale during long parks; that's expected and the strategy uses it
    to decide whether a wake POST is needed.
  - `..._status_refresh_state` - one of `active`, `soft_disabled_unreachable`
    (per-VIN failed-wake threshold hit), `hard_disabled_auto`
    (config-entry-wide flag set after any VIN hit the POST-rejection
    threshold), or `hard_disabled_user` (user-disabled in options flow).
    Note that `soft_disabled_unreachable` is per-VIN and clears
    automatically; `hard_disabled_auto` is shared across all VINs in the
    config entry and clears only via the user toggling
    `enable_status_refresh` off then on.
- **Retain-track diagnostics** (sensor, per vehicle, exposed regardless of
  `retain_on_transient_failure` but only practically useful when retain is
  ON, since OFF surfaces the same information by rendering data sensors
  as `unavailable`):
  - `..._last_successful_fetch` - **HA-side wall-clock timestamp** of the
    last cycle where this VIN's overall `vehicle.update()` sweep
    succeeded. Distinct from `_status_last_reported_by_car`: this is "when
    did the integration last get any response from Toyota's API",
    independent of whether that response carried fresh modem data or
    stale gateway-cache data. With retain ON, this is the only signal
    that distinguishes "data sensors are showing fresh values" from "data
    sensors are showing last-known cached values because the most recent
    fetch failed".
  - `..._last_error_time` - timestamp of the most recent failure for this
    VIN. Pairs with `last_successful_fetch` for "is the integration
    healthy right now or coasting on cached data".
  - `..._last_error_code` - the error code captured at that time (HTTP
    status like `429`, or exception class name like `ConnectTimeout`).
- **Refresh service**: `toyota.refresh_vehicle_status` - HA service that
  fires a wake POST for a given VIN. For automations (e.g. "if I open my
  app, refresh first").

### New options-flow toggles (Settings → Integrations → Toyota → Configure)

7 new options, defaults chosen so a fresh install gets sensible behaviour
without touching anything:

| Option | Default | What it controls |
|---|---|---|
| `polling_interval_minutes` | `6` | How often the coordinator runs. Each cycle either calls or skips the gateway based on the strategy below. Range 5-60. |
| `enable_status_refresh` | `true` | Master switch for the wake POST. When OFF, the coordinator never calls `POST /refresh-status` - it falls back to bare GETs and the four options below have no effect. **Setting this OFF reproduces pre-PR behaviour for users who want to opt out of the wake mechanism entirely.** Also serves as the lift-off path for the auto-disable: toggling this OFF then ON clears `auto_disabled_status_refresh` if it was set after a vehicle hit the POST-rejection threshold. |
| `post_count_per_stop` | `2` | Wake POSTs to fire when a stop is detected. The first one goes out the cycle the stop is detected; the second fires on the next cycle to catch user actions right after parking (locking doors, opening trunk). Higher values rarely help and burn 12 V battery. |
| `max_cache_age_minutes` | `30` | Maximum age of the gateway's cached `/status` payload before the strategy issues a fresh GET (independent of any POST). Range 5-180. |
| `idle_wake_hours` | `0` | Periodic `POST /refresh-status` for cars that sit unused for days, so door / window / lock state stays current rather than going stale for the whole park. `0` = disabled (default - we let the car stay quiet). `1-72` = wake every N hours. Other endpoints (odometer, fuel, location, EV state) keep being fetched on every cycle regardless and don't need this; this option is only for the wake-POST path. Costs cellular airtime and a small amount of 12V battery per wake. |
| `failed_wake_threshold` | `3` | Consecutive failed wakes (POST OK, GET poll never sees `occurrence_date` advance) before the VIN is soft-disabled. Cleared automatically by any sign of life. |
| `retain_on_transient_failure` | `false` | When ON, a transient API failure on a VIN keeps last-known sensor values in place instead of rendering as `unavailable`. **Default OFF reproduces pre-PR behaviour** - sensors flip to `unavailable` on any failed cycle. The three retain-track diagnostic sensors (`last_successful_fetch`, `last_error_time`, `last_error_code`) tell the user when retain is masking a stale value. |

### What this looks like in practice

> **Scope reminder**: the `GET_ONLY` / `SERVE_FROM_CACHE` / `POST_THEN_GET`
> decisions in the tables below apply **only to `/v1/global/remote/status`**
> (door, hood, window, lock). That endpoint is where 429s and stale data
> have historically clustered, so the strategy + the HA-side retain cache
> + the reduced GET frequency are all targeted there. Every other sensor
> (odometer, fuel, location, EV state, trips, etc.) is fetched on every
> coordinator cycle exactly as before; this PR doesn't touch their cadence.

With every option at its default, here are four typical scenarios. Each
row is one coordinator cycle (every 6 minutes):

**A. Car parked all day, no movement**

| Time | Strategy decision | Network calls |
|---|---|---|
| 00:00 | `GET_ONLY` (cache empty) | 1 × GET `/status` |
| 00:06 | `SERVE_FROM_CACHE` (cache 6 min old, < 30) | 0 |
| 00:12 | `SERVE_FROM_CACHE` | 0 |
| 00:18 | `SERVE_FROM_CACHE` | 0 |
| 00:24 | `SERVE_FROM_CACHE` | 0 |
| 00:30 | `GET_ONLY` (cache hit `max_cache_age_minutes`) | 1 × GET |
| ... | repeats | 2 × GET / hour, 0 POSTs |

**B. Car drives for ~25 min then parks (typical commute)**

| Time | What happened | Strategy decision | Network calls |
|---|---|---|---|
| 08:00 | parked overnight, cache stale | `GET_ONLY` (cache_stale) | 1 × GET |
| 08:06 | car just started driving (odometer delta) | `SERVE_FROM_CACHE` (currently_moving - cache still fresh) | 0 |
| 08:12 | still driving | `SERVE_FROM_CACHE` | 0 |
| 08:18 | still driving | `SERVE_FROM_CACHE` | 0 |
| 08:24 | car parked between cycles | `POST_THEN_GET` (`just_stopped`) | 1 × POST + GET poll |
| 08:30 | followup window | `POST_THEN_GET` (`just_stopped_followup`) | 1 × POST + GET poll |
| 08:36 | parked, cache fresh from 6 min ago | `SERVE_FROM_CACHE` | 0 |
| 08:42 onwards | back to scenario A pattern | | |

Result for the commute: **2 POSTs + 1 standalone GET** (the wake actions
also do their own internal GET polls, but those are bounded by the 25s
budget). Compare to the legacy behaviour: **7 bare GETs** over the same
period, all of them returning whatever the cache happened to hold.

**C. User taps the "Refresh vehicle status" button (or calls the service)**

| Time | What happened | Strategy decision | Network calls |
|---|---|---|---|
| 14:23 | user tap | `POST_THEN_GET` (`service_call`, fires immediately - bypasses the 6-min cycle) | 1 × POST + GET poll |

The button triggers a fresh strategy run for that VIN regardless of cycle
timing. Sibling vehicles are unaffected.

**D. Car has been parked 36 hours, `idle_wake_hours = 24` configured**

| Time | What happened | Strategy decision | Network calls |
|---|---|---|---|
| Day 1 12:00 | parking established, scenario A applies | `SERVE_FROM_CACHE` / `GET_ONLY` | 2 × GET / hour |
| Day 2 12:00 | 24h since last wake | `POST_THEN_GET` (`idle_wake`) | 1 × POST + GET poll |
| Day 2 onwards | scenario A resumes | | |

**Where wakes do NOT fire** under defaults: while the car is moving (we use
GETs only - the modem auto-reports during driving anyway), when cache is
fresh and no trigger fires, when refresh-status has been auto-disabled at
the config-entry level after any VIN hit 2 consecutive POST rejections
(affects all VINs in that entry), and when this specific VIN has been
soft-disabled after 3 consecutive failed wakes (per-VIN, doesn't affect
siblings).

## Test plan

- [x] `poetry run pre-commit run --all-files` clean
- [x] `poetry run pytest` green (28 tests across 3 files: `test_refresh_strategy.py`
      with 21 unit tests for the decision tree, `test_binary_sensor_null_fix.py`
      with 5 tests for #87, `test_config_flow.py` with 2)
- [x] Validated live on a 2-vehicle account, real-drive scenario (~15 min RAV4):
      strategy timeline played out exactly per design - `currently_moving`
      caught the odometer delta, `just_stopped` fired the wake POST,
      `just_stopped_followup` fired the second POST, both returned `000000`,
      `occurrence_date` advanced in real time. 0 errors, 0 429s on `/status`,
      0 auto-disables. Cache re-injection layer confirmed: lock state stayed
      stable across `SERVE_FROM_CACHE` cycles in between.
- [x] 24h+ soak on the same live deploy.

## Empirical findings worth recording

Three observations from the live deploy:

1. **A bare GET reads stale cache, period.** Manual physical activity
   (door open + close on a parked car) does NOT propagate to the gateway
   cache. ECU events go nowhere; only modem reports do.
2. **Toyota's modem auto-reports on park, not during driving.** Mid-drive
   bare GETs return stale cache. Post-stop bare GETs return fresh data
   ~30 s old.
3. **The wake POST does not appear to reduce the 429 rate.** Empirically,
   429s remain stochastic before and after introducing the wake POST. The
   resilience improvements in this PR come from three places that are
   each independently effective:
   - **Lower call frequency**: smart strategy avoids GET when cache is
     known-fresh and skips redundant cycles, so we hit the gateway less
     overall.
   - **Retry-with-backoff** (in pytoyoda): transient 429s now retry
     internally instead of bubbling as failures.
   - **`retain_on_transient_failure`**: when a 429 does bubble, sensors
     keep last-good values instead of going `unavailable`.
   The wake POST is preserved because it does still produce fresh
   `occurrence_date` values after stops (validated repeatedly in the gist
   timeline) - just not because it dodges 429s.

## Linked issues

**Resolves** (direct code fix):
- [#87](https://github.com/pytoyoda/ha_toyota/issues/87) - null binary_sensors render as on (door/lock/window)

**Substantially mitigates** (combined effect of wake POSTs + retain + lower
GET frequency, but stochastic 429s remain possible):
- [#137](https://github.com/pytoyoda/ha_toyota/issues/137) - lock state stuck stale
- [#157](https://github.com/pytoyoda/ha_toyota/issues/157) /
  [#168](https://github.com/pytoyoda/ha_toyota/issues/168) - door state inaccurate
- [#190](https://github.com/pytoyoda/ha_toyota/issues/190) - door/lock state not updating
- [#229](https://github.com/pytoyoda/ha_toyota/issues/229) - lock binary_sensor stuck
- [#281](https://github.com/pytoyoda/ha_toyota/issues/281) /
  [#284](https://github.com/pytoyoda/ha_toyota/issues/284) - 429 flood on `/status`

**Documents but does not claim to fix**:
- [pytoyoda#161](https://github.com/pytoyoda/pytoyoda/issues/161) - cache-expiry mechanic. Per the empirical findings above, we don't fully understand the 429 cause and don't claim to address it directly; the resilience comes from elsewhere.

## Behavioural deltas worth flagging for review

- **Traffic and cost**: under defaults a typical parking event costs
  two wake POSTs (a small amount of cellular airtime + 12V draw); the rest
  of the cycle is mostly cache-served. Net `/status` GET traffic is roughly
  6× lower than the legacy "one GET every 6-min cycle" pattern.
- **Per-vehicle scoping (with one exception)**: retain, fault isolation,
  failed-wake soft-disable, and the per-VIN counters are all per-VIN. A
  transient 429 on one car never affects the others. The exception is
  the auto-disable on POST rejections: once any VIN has 2 consecutive
  non-`000000` returns, the wake mechanism is hard-disabled for the
  whole config entry (not just that VIN), since a rejection signals
  permanent feature unsupport rather than a transient error. Mixed-fleet
  users (one supporting + one unsupporting vehicle in the same config
  entry) trade automatic wakes for the supporting vehicle but still have
  the `toyota.refresh_vehicle_status` service call for on-demand
  per-VIN refreshes from automations. The hard-disable is cleared by
  toggling `enable_status_refresh` OFF then ON.
- **Opt-out reproduces pre-PR behaviour exactly**: setting
  `enable_status_refresh=false` reverts the `/status` path to bare GETs;
  `retain_on_transient_failure=false` (default) keeps the legacy "go
  unavailable on any error" rendering.