### PR TITLE
Gracefully handle climate-settings HTTP 500 (fixes #294)

### DIFF
--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -593,11 +593,21 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
         # Bounded so a slow/flaky non-status endpoint can't stall first_refresh
         # past HA's setup budget. On timeout the TimeoutError propagates to the
         # caller's per-vehicle handler, which serves cache or a stub - same
-        # degrade path as any other transient Toyota failure.
-        await asyncio.wait_for(
-            _call_tagged("vehicle.update", vin, vehicle.update(skip=["status"])),
-            STATUS_FETCH_BUDGET_S,
-        )
+        # degrade path as any other transient Toyota failure. A climate-settings
+        # (or other endpoint) HTTP 500 surfaces here as a ToyotaApiError/
+        # ToyotaInternalError - swallow it so a single bad endpoint doesn't fail
+        # the whole refresh; the rest of the snapshot still builds from cache.
+        try:
+            await asyncio.wait_for(
+                _call_tagged("vehicle.update", vin, vehicle.update(skip=["status"])),
+                STATUS_FETCH_BUDGET_S,
+            )
+        except (ToyotaApiError, ToyotaInternalError) as ex:
+            _LOGGER.warning(
+                "vehicle.update partial failure for vin=...%s (%s), continuing",
+                (vin or "")[-6:],
+                _error_code(ex),
+            )
 
         # Build snapshot for the strategy.
         current_odometer_km: float | None = None

--- a/custom_components/toyota/climate.py
+++ b/custom_components/toyota/climate.py
@@ -230,8 +230,11 @@ class ToyotaClimate(ToyotaBaseEntity, ClimateEntity):
         Returns:
             ClimateSettingsModel configured with the specified settings
         """
-        # Start with existing operations (None when climate-settings 500'd)
-        ac_operations = (self.vehicle.climate_settings.operations or []).copy()
+        # Start with existing operations. climate_settings itself (not just
+        # .operations) can be None when the climate-settings endpoint 500'd, so
+        # getattr through both to avoid an AttributeError on the control path.
+        climate_settings = getattr(self.vehicle, "climate_settings", None)
+        ac_operations = (getattr(climate_settings, "operations", None) or []).copy()
 
         # Find and replace the defrost operation
         for i, operation in enumerate(ac_operations):

--- a/custom_components/toyota/climate.py
+++ b/custom_components/toyota/climate.py
@@ -123,7 +123,7 @@ class ToyotaClimate(ToyotaBaseEntity, ClimateEntity):
     def _load_climate_settings_from_coordinator(self) -> None:
         """Load climate settings from coordinator data if available."""
         try:
-            if not self.vehicle or not hasattr(self.vehicle, "climate_settings"):
+            if not self.vehicle or not getattr(self.vehicle, "climate_settings", None):
                 _LOGGER.debug("Vehicle climate_settings not yet available")
                 return
 
@@ -147,18 +147,24 @@ class ToyotaClimate(ToyotaBaseEntity, ClimateEntity):
         """Load temperature settings from climate_settings."""
         climate_settings = self.vehicle.climate_settings
         target_temperature = climate_settings.temperature
-        if target_temperature is not None:
+        if target_temperature is not None and target_temperature.value is not None:
             self._attr_target_temperature = target_temperature.value
-        self._attr_min_temp = getattr(climate_settings, "min_temp", 18)
-        self._attr_max_temp = getattr(climate_settings, "max_temp", 29)
-        self._attr_target_temperature_step = getattr(
-            climate_settings, "temp_interval", 1
+        # `or <default>` guards against the attribute existing but being None
+        # (climate-settings HTTP 500). A None min/max_temp makes HA core's
+        # set_temperature validation do `float < None` -> TypeError; keep the
+        # __init__ defaults (18/29/1) instead.
+        self._attr_min_temp = getattr(climate_settings, "min_temp", None) or 18
+        self._attr_max_temp = getattr(climate_settings, "max_temp", None) or 29
+        self._attr_target_temperature_step = (
+            getattr(climate_settings, "temp_interval", None) or 1
         )
 
     def _load_defrost_settings(self) -> None:
         """Load defrost settings from climate_settings operations."""
         climate_settings = self.vehicle.climate_settings
-        operations = getattr(climate_settings, "operations", [])
+        # API can return operations=None (e.g. climate-settings HTTP 500);
+        # `or []` guards against the attribute existing but being None.
+        operations = getattr(climate_settings, "operations", None) or []
         for operation in filter(lambda o: o.category_name == "defrost", operations):
             for param in operation.parameters:
                 if param.name == "frontDefrost":
@@ -224,8 +230,8 @@ class ToyotaClimate(ToyotaBaseEntity, ClimateEntity):
         Returns:
             ClimateSettingsModel configured with the specified settings
         """
-        # Start with existing operations
-        ac_operations = self.vehicle.climate_settings.operations.copy()
+        # Start with existing operations (None when climate-settings 500'd)
+        ac_operations = (self.vehicle.climate_settings.operations or []).copy()
 
         # Find and replace the defrost operation
         for i, operation in enumerate(ac_operations):

--- a/custom_components/toyota/manifest.json
+++ b/custom_components/toyota/manifest.json
@@ -7,9 +7,6 @@
   "documentation": "https://github.com/pytoyoda/ha_toyota",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pytoyoda/ha_toyota/issues",
-  "requirements": [
-    "pytoyoda>=5.1.0,<6.0",
-    "arrow"
-  ],
+  "requirements": ["pytoyoda>=5.1.0,<6.0", "arrow"],
   "version": "v2.3.0"
 }


### PR DESCRIPTION
## Problem

On some HEV/PHEV vehicles the `/v1/global/remote/climate-settings` endpoint returns HTTP 500 even though remote climate works in the MyToyota app (#294). Two failure modes result:

1. The unguarded `vehicle.update()` call propagates the error and aborts the entire refresh cycle, taking otherwise-healthy endpoints down with it.
2. When `climate_settings` does come back partially populated, `operations`/`min_temp`/`max_temp` are `None`, so `filter(operation, None)` raises `TypeError` every update cycle and HA-core's `set_temperature` validation does `float < None` → `TypeError`. Logs fill with retries/tracebacks and the climate entity never settles.

## Fix (integration-layer, minimal)

- Wrap the manual `vehicle.update(skip=["status"])` in `try`/`except (ToyotaApiError, ToyotaInternalError)` and log a warning, so one failing endpoint no longer aborts the refresh.
- None-guard `climate_settings` in `climate.py`: fall back to the existing `__init__` defaults (18/29/1) for min/max/step and treat `operations=None` as `[]`. The climate entity degrades gracefully instead of erroring.

This is the auto-disable-style graceful handling #294's reporter explicitly asked for. The 500 originates Toyota-side, so the fix is independent of the pytoyoda version/provider; it also complements the recent BEV climate enablement (pytoyoda `f7f67eb` + `ea73031`), which makes more vehicles reach this endpoint.

## Testing

Running in production for ~1 week (since 2026-06-15) on a Corolla Touring Sports (v2.3.0, HA 2026.5.x) whose climate-settings endpoint 500s consistently. Before: refresh aborted + per-cycle `TypeError` spam. After: climate entity loads with sane defaults, the spam stops, and the rest of the refresh completes normally. `ruff` + `ruff-format` clean.

## Compatibility

No config/schema changes. Healthy vehicles (valid `climate_settings`) are unaffected — guards only change behaviour on the `None`/500 path.