### PR TITLE
Bound setup fetches so a Toyota outage can't wedge config-entry setup

### DIFF
--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -703,7 +703,15 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
                 asyncioexceptions.TimeoutError,
                 ToyotaApiError,
                 ToyotaInternalError,
+                httpx.ConnectTimeout,
+                httpcore.ConnectTimeout,
+                httpx.ReadTimeout,
+                ValidationError,
             ) as ex:
+                # Degrade on ANY transient summary failure (matches the family
+                # the per-vehicle handler treats as recoverable). NOT
+                # CancelledError: a real outer cancel must propagate, and
+                # wait_for already surfaces its own timeout as TimeoutError.
                 cached_stats = (
                     last_good_per_vin[vin]["statistics"]
                     if vin in last_good_per_vin

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -70,6 +70,18 @@ _LOGGER = logging.getLogger(__name__)
 # requests against the gateway.
 STRATEGY_DEFAULT_WAKE_TIMEOUT_S = 25
 
+# Per-cycle wall-clock budgets that keep a single Toyota-side outage from
+# blocking config-entry setup. The /v1/trips summary endpoints are the slowest
+# + flakiest Toyota surface (each call retries 4x with 2/4/8s backoff inside
+# pytoyoda on a 5xx), so an unbounded summary fetch can stall first_refresh
+# ~45s+ - long enough to overrun HA's bootstrap setup budget, get the setup
+# cancelled mid platform-forward, and leave the platforms half-registered
+# ("... has already been setup"). Bounding both the status fetch and the
+# summary fetch makes first_refresh complete (or fail cleanly) in bounded time
+# so HA can do its own backoff retry instead of wedging the entry.
+STATUS_FETCH_BUDGET_S = 20
+SUMMARY_FETCH_BUDGET_S = 12
+
 
 def loguru_to_hass(message: str) -> None:
     """Forward Loguru logs to standard Python logger used by HACS."""
@@ -578,7 +590,14 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
         # 429+APIGW-403 from a stale cache that we can avoid entirely by
         # POSTing first OR by serving from cache. Note: vehicle.update() also
         # populates _endpoint_data["telemetry"], which we read for odometer.
-        await _call_tagged("vehicle.update", vin, vehicle.update(skip=["status"]))
+        # Bounded so a slow/flaky non-status endpoint can't stall first_refresh
+        # past HA's setup budget. On timeout the TimeoutError propagates to the
+        # caller's per-vehicle handler, which serves cache or a stub - same
+        # degrade path as any other transient Toyota failure.
+        await asyncio.wait_for(
+            _call_tagged("vehicle.update", vin, vehicle.update(skip=["status"])),
+            STATUS_FETCH_BUDGET_S,
+        )
 
         # Build snapshot for the strategy.
         current_odometer_km: float | None = None
@@ -654,20 +673,50 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
             # summary calls in an asyncio.gather within the same event-loop
             # tick reliably trips a 429 with {"description": "Unauthorized"}
             # response bodies. See pytoyoda/ha_toyota#282.
-            statistics = StatisticsData(
-                day=await _call_tagged(
-                    "day_summary", vin, vehicle.get_current_day_summary()
-                ),
-                week=await _call_tagged(
-                    "week_summary", vin, vehicle.get_current_week_summary()
-                ),
-                month=await _call_tagged(
-                    "month_summary", vin, vehicle.get_current_month_summary()
-                ),
-                year=await _call_tagged(
-                    "year_summary", vin, vehicle.get_current_year_summary()
-                ),
-            )
+            async def _fetch_summaries() -> StatisticsData:
+                return StatisticsData(
+                    day=await _call_tagged(
+                        "day_summary", vin, vehicle.get_current_day_summary()
+                    ),
+                    week=await _call_tagged(
+                        "week_summary", vin, vehicle.get_current_week_summary()
+                    ),
+                    month=await _call_tagged(
+                        "month_summary", vin, vehicle.get_current_month_summary()
+                    ),
+                    year=await _call_tagged(
+                        "year_summary", vin, vehicle.get_current_year_summary()
+                    ),
+                )
+
+            # Summaries are secondary telemetry: bound the whole block and
+            # degrade gracefully rather than letting a /v1/trips outage block
+            # setup or stub out the whole car. On timeout/API-error we hold the
+            # last-known statistics (or None) and still return this cycle's
+            # fresh status data. wait_for cancels the inner coro on timeout,
+            # which _call_tagged surfaces as a per-endpoint "cancelled" log.
+            try:
+                statistics = await asyncio.wait_for(
+                    _fetch_summaries(), SUMMARY_FETCH_BUDGET_S
+                )
+            except (
+                asyncioexceptions.TimeoutError,
+                ToyotaApiError,
+                ToyotaInternalError,
+            ) as ex:
+                cached_stats = (
+                    last_good_per_vin[vin]["statistics"]
+                    if vin in last_good_per_vin
+                    else None
+                )
+                _LOGGER.warning(
+                    "Toyota summary fetch for vin=...%s degraded (%s); "
+                    "holding %s statistics",
+                    vin[-6:],
+                    _error_code(ex),
+                    "last-known" if cached_stats is not None else "no",
+                )
+                statistics = cached_stats
         now = dt_util.now()
         # NB: do NOT update last_fetch_time_per_vin here. We need commit
         # semantics matching coordinator.data: if a later vehicle in the loop


### PR DESCRIPTION
## Problem

A cold start that coincides with a Toyota-side 5xx storm on the `/v1/trips` summary endpoints stalls `async_config_entry_first_refresh` ~46s — each of the 4 summary calls retries 4× with 2/4/8s backoff inside pytoyoda. That overruns HA's bootstrap setup budget: setup is cancelled mid platform-forward, the half-registered platforms then fail every retry with "… has already been setup", and the entry stays wedged until a manual reload.

## Fix

Bound both external fetches in `_refresh_one_vehicle` so `first_refresh` completes — or fails cleanly — in bounded time, letting HA do its own backoff retry instead of wedging:

- Summary block wrapped in `asyncio.wait_for(SUMMARY_FETCH_BUDGET_S=12)`; on timeout/API-error, hold last-known statistics (or `None`) and still return this cycle's fresh status data rather than stubbing the whole car.
- `vehicle.update(skip=["status"])` wrapped in `wait_for(STATUS_FETCH_BUDGET_S=20)`, degrading to the existing cache/stub path on timeout.
- Broaden the summary-degrade catch to the full transient-error family the per-vehicle handler already treats as recoverable (timeouts, `ToyotaApiError`/`ToyotaInternalError`, `ValidationError`) — deliberately not `CancelledError`, so a real outer cancel still propagates.

## Relationship to existing work

Orthogonal to `0b0c06a` ("use proper config dir path"), which fixes a different setup failure (writable cwd + a `TypeError` catch). This addresses the time-budget failure mode, and may help reports like #291/#281.

## Testing / Compatibility

`ruff` + `ruff-format` clean; `py_compile` OK. No config/schema changes; the happy path is unchanged (budgets only fire on a stalled fetch). Budgets are conservative (20s/12s) relative to HA's setup window.