### PR TITLE
Import TrackerEntity from the public device_tracker path

### DIFF
--- a/custom_components/toyota/device_tracker.py
+++ b/custom_components/toyota/device_tracker.py
@@ -2,8 +2,7 @@
 
 # pylint: disable=W0212, W0511
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker import SourceType, TrackerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityDescription

--- a/custom_components/toyota/manifest.json
+++ b/custom_components/toyota/manifest.json
@@ -7,9 +7,6 @@
   "documentation": "https://github.com/pytoyoda/ha_toyota",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pytoyoda/ha_toyota/issues",
-  "requirements": [
-    "pytoyoda>=5.1.0,<6.0",
-    "arrow"
-  ],
+  "requirements": ["pytoyoda>=5.1.0,<6.0", "arrow"],
   "version": "v2.3.0"
 }


### PR DESCRIPTION
`homeassistant.components.device_tracker.config_entry.TrackerEntity` is a deprecated alias for `homeassistant.components.device_tracker.TrackerEntity` — it emits a `DeprecationWarning` and is scheduled for removal in **HA 2027.6** (see core's `device_tracker/config_entry.py`: `_DEPRECATED_TrackerEntity = DeprecatedAlias(_TrackerEntity, "homeassistant.components.device_tracker.TrackerEntity", "2027.6")`).

This imports `TrackerEntity` from the top-level `device_tracker` package alongside `SourceType` (one consolidated import line) to silence the warning and stay compatible past 2027.6. No behaviour change.

Heads-up: the **Hassfest** check will likely fail here, but on a repo-wide manifest issue unrelated to this PR — the `manifest.json` `pytoyoda @ git+…` requirement (see #310 for the same failure).