### PR TITLE
feat: vehicle-health problem binary sensor

### DIFF
--- a/custom_components/toyota/binary_sensor.py
+++ b/custom_components/toyota/binary_sensor.py
@@ -337,8 +337,23 @@ TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescription(
 
 
 def _health_warnings(vehicle: Vehicle) -> list[Any] | None:
-    """The vehicle-health warning list, or None if health never reported."""
-    return getattr(getattr(vehicle, "dashboard", None), "warning_lights", None)
+    """The vehicle-health warning list, or None if health has not reported.
+
+    ``vehicle.dashboard`` is an uncached computed property (constructs a new
+    Dashboard each access), so callers should bind this result once per read.
+    """
+    dashboard = vehicle.dashboard
+    return dashboard.warning_lights if dashboard else None
+
+
+def _health_problem_state(vehicle: Vehicle) -> bool | None:
+    """Problem state: on = warnings present, off = empty list, None = unknown.
+
+    Note: an endpoint that reports ``warning: null`` is indistinguishable from
+    one that never reported — both read as unknown, never as a false "off".
+    """
+    warnings = _health_warnings(vehicle)
+    return None if warnings is None else len(warnings) > 0
 
 
 VEHICLE_HEALTH_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescription(
@@ -347,13 +362,7 @@ VEHICLE_HEALTH_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescription(
     icon="mdi:car-wrench",
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=BinarySensorDeviceClass.PROBLEM,
-    # on = the car reports at least one health warning; off = an explicit
-    # empty warning list; unknown = the health endpoint has not reported.
-    value_fn=lambda vehicle: (
-        None
-        if _health_warnings(vehicle) is None
-        else len(_health_warnings(vehicle)) > 0
-    ),
+    value_fn=_health_problem_state,
     attributes_fn=lambda vehicle: {
         "warnings": _health_warnings(vehicle),
     },
@@ -496,8 +505,12 @@ async def async_setup_entry(
                 ),
                 TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION,
             ),
-            # pytoyoda fetches the vehicle-health endpoint unconditionally
-            # (no capability flag); an unreported endpoint reads as unknown.
+            # Deliberately not gated on extended_capabilities
+            # (dashboard_warning_lights) or features.vehicle_health_report:
+            # pytoyoda fetches the health endpoint unconditionally, and Toyota
+            # capability flags under-report actual support (e.g. steering_heater
+            # is False on cars that honor it). An endpoint that never reports
+            # simply reads as unknown.
             (
                 True,
                 VEHICLE_HEALTH_ENTITY_DESCRIPTION,

--- a/custom_components/toyota/binary_sensor.py
+++ b/custom_components/toyota/binary_sensor.py
@@ -336,6 +336,30 @@ TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescription(
 )
 
 
+def _health_warnings(vehicle: Vehicle) -> list[Any] | None:
+    """The vehicle-health warning list, or None if health never reported."""
+    return getattr(getattr(vehicle, "dashboard", None), "warning_lights", None)
+
+
+VEHICLE_HEALTH_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescription(
+    key="vehicle_health",
+    translation_key="vehicle_health",
+    icon="mdi:car-wrench",
+    entity_category=EntityCategory.DIAGNOSTIC,
+    device_class=BinarySensorDeviceClass.PROBLEM,
+    # on = the car reports at least one health warning; off = an explicit
+    # empty warning list; unknown = the health endpoint has not reported.
+    value_fn=lambda vehicle: (
+        None
+        if _health_warnings(vehicle) is None
+        else len(_health_warnings(vehicle)) > 0
+    ),
+    attributes_fn=lambda vehicle: {
+        "warnings": _health_warnings(vehicle),
+    },
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -471,6 +495,12 @@ async def async_setup_entry(
                     False,
                 ),
                 TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION,
+            ),
+            # pytoyoda fetches the vehicle-health endpoint unconditionally
+            # (no capability flag); an unreported endpoint reads as unknown.
+            (
+                True,
+                VEHICLE_HEALTH_ENTITY_DESCRIPTION,
             ),
         ]
 

--- a/custom_components/toyota/translations/en.json
+++ b/custom_components/toyota/translations/en.json
@@ -215,6 +215,9 @@
       },
       "taillights": {
         "name": "Taillights"
+      },
+      "vehicle_health": {
+        "name": "Vehicle health"
       }
     },
     "climate": {


### PR DESCRIPTION
## What
Adds a `PROBLEM`-class diagnostic binary sensor surfacing the vehicle-health endpoint pytoyoda already fetches on every update — zero additional API traffic.

- **on** = the car reports at least one health warning (`dashboard.warning_lights` non-empty)
- **off** = an explicit empty warning list
- **unknown** = the endpoint has not reported
- Warning details exposed via the `warnings` attribute; `translation_key` + `en.json` entry included.

## Why
The health data is fetched by pytoyoda unconditionally but never surfaced in HA. A problem-class sensor makes dashboard-warning-light state automatable (push notification on car trouble).

Deliberately not gated on `extended_capabilities.dashboard_warning_lights`: Toyota capability flags under-report actual support (e.g. `steering_heater` is `False` on cars that honor the command), and pytoyoda fetches the endpoint for every car; a never-reporting endpoint simply reads unknown. Happy to switch to flag-gating if you prefer.

`vehicle.dashboard` is an uncached computed property, so the value is bound once per read.

## Tested
Live on a Corolla TS 2.0 Hybrid (EU): healthy car reads `off` with `warnings: []`; endpoint timestamp advances on poll. Ruff/pre-commit clean.