### PR TITLE
feat: last-service date sensor from service history

### DIFF
--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -253,6 +253,34 @@ REMAINING_CHARGE_TIME_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
     attributes_fn=lambda vehicle: None,  # noqa : ARG005
 )
 
+
+def _last_service_attributes(vehicle: Vehicle) -> dict[str, Any] | None:
+    """Attributes for the last-service sensor; None until history reports."""
+    latest = vehicle.get_latest_service_history()
+    if latest is None:
+        return None
+    return {
+        "odometer": latest.odometer,
+        "service_category": latest.service_category,
+        "service_provider": latest.service_provider,
+        "customer_created_record": latest.customer_created_record,
+        "service_count": len(vehicle.service_history or []),
+    }
+
+
+LAST_SERVICE_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
+    key="last_service",
+    translation_key="last_service",
+    icon="mdi:wrench-clock",
+    entity_category=EntityCategory.DIAGNOSTIC,
+    device_class=SensorDeviceClass.DATE,
+    state_class=None,
+    value_fn=lambda vehicle: getattr(
+        vehicle.get_latest_service_history(), "service_date", None
+    ),
+    attributes_fn=_last_service_attributes,
+)
+
 STATISTICS_ENTITY_DESCRIPTIONS_DAILY = ToyotaStatisticsSensorEntityDescription(
     key="current_day_statistics",
     translation_key="current_day_statistics",
@@ -396,6 +424,18 @@ def create_sensor_configurations(metric_values: bool) -> list[dict[str, Any]]:  
             ),
             "native_unit": "min",
             "suggested_unit": "min",
+        },
+        {
+            "description": LAST_SERVICE_ENTITY_DESCRIPTION,
+            # Mirror pytoyoda's own gate for the service-history endpoint
+            # (features, not extended_capabilities).
+            "capability_check": lambda v: getattr(
+                getattr(v._vehicle_info, "features", False),  # noqa : SLF001
+                "service_history",
+                False,
+            ),
+            "native_unit": None,
+            "suggested_unit": None,
         },
         {
             "description": STATISTICS_ENTITY_DESCRIPTIONS_DAILY,

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -282,16 +282,15 @@ def _last_service_state(vehicle: Vehicle) -> date | None:
 
 def _last_service_attributes(vehicle: Vehicle) -> dict[str, Any] | None:
     """Attributes for the last-service sensor; None until history reports."""
-    history = vehicle.service_history
-    if not history:
+    latest = _latest_service(vehicle)
+    if latest is None:
         return None
-    latest = max(history, key=_service_recency_key)
     return {
         "odometer": latest.odometer,
         "service_category": latest.service_category,
         "service_provider": latest.service_provider,
         "customer_created_record": latest.customer_created_record,
-        "service_count": len(history),
+        "service_count": len(vehicle.service_history),
     }
 
 

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import date
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from homeassistant.components.sensor import (
@@ -34,6 +35,7 @@ if TYPE_CHECKING:
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
     from homeassistant.helpers.typing import StateType
     from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+    from pytoyoda.models.service_history import ServiceHistory
     from pytoyoda.models.vehicle import Vehicle
 
     from . import StatisticsData, VehicleData
@@ -254,17 +256,42 @@ REMAINING_CHARGE_TIME_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
 )
 
 
+def _service_recency_key(record: ServiceHistory) -> tuple[date, str]:
+    """Sort key for the newest service record, tolerating null fields."""
+    return (record.service_date or date.min, record.service_category or "")
+
+
+def _latest_service(vehicle: Vehicle) -> ServiceHistory | None:
+    """The newest service record, or None until history reports.
+
+    Not pytoyoda's ``get_latest_service_history()``: that raises ValueError on
+    an empty history list and TypeError when a record's service_date or
+    service_category is null (its max() key compares None against date/str).
+    """
+    history = vehicle.service_history
+    if not history:
+        return None
+    return max(history, key=_service_recency_key)
+
+
+def _last_service_state(vehicle: Vehicle) -> date | None:
+    """State for the last-service sensor: the newest record's service date."""
+    latest = _latest_service(vehicle)
+    return latest.service_date if latest else None
+
+
 def _last_service_attributes(vehicle: Vehicle) -> dict[str, Any] | None:
     """Attributes for the last-service sensor; None until history reports."""
-    latest = vehicle.get_latest_service_history()
-    if latest is None:
+    history = vehicle.service_history
+    if not history:
         return None
+    latest = max(history, key=_service_recency_key)
     return {
         "odometer": latest.odometer,
         "service_category": latest.service_category,
         "service_provider": latest.service_provider,
         "customer_created_record": latest.customer_created_record,
-        "service_count": len(vehicle.service_history or []),
+        "service_count": len(history),
     }
 
 
@@ -275,9 +302,7 @@ LAST_SERVICE_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
     entity_category=EntityCategory.DIAGNOSTIC,
     device_class=SensorDeviceClass.DATE,
     state_class=None,
-    value_fn=lambda vehicle: getattr(
-        vehicle.get_latest_service_history(), "service_date", None
-    ),
+    value_fn=_last_service_state,
     attributes_fn=_last_service_attributes,
 )
 

--- a/custom_components/toyota/translations/en.json
+++ b/custom_components/toyota/translations/en.json
@@ -142,6 +142,9 @@
           "hard_disabled_auto": "Disabled (unsupported)",
           "hard_disabled_user": "Disabled (by user)"
         }
+      },
+      "last_service": {
+        "name": "Last service"
       }
     },
     "button": {


### PR DESCRIPTION
## What
Adds a `DATE`-class diagnostic sensor whose state is the most recent service date, from the service-history endpoint pytoyoda already fetches — zero additional API traffic. Attributes: odometer at service, category, provider, customer-created flag, total record count. Gated on the same `features.service_history` flag pytoyoda uses for the fetch itself.

## Why
Service history is fetched but never surfaced; a last-service date makes 'months since service' reminders a one-line template.

## Note on record selection
The sensor selects the newest record locally with a null-tolerant key instead of calling `vehicle.get_latest_service_history()`, which raises `ValueError` on an empty history list (`max([])`) and `TypeError` when a record's `service_date`/`service_category` is null (its `max()` key compares `None` against `date`/`str`). Both are reachable: a car with the feature flag but zero dealer records, or a customer-created record missing a date. I can send a small pytoyoda PR fixing the helper itself if you'd like — then this can switch back to it.

## Tested
Live on a Corolla TS (EU), 13 dealer records: state `2026-05-20`, attributes populated (`odometer: 57137`, provider, category). Ruff/pre-commit clean.