### PR TITLE
feat: notifications count sensor with recent-message attributes

### DIFF
--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -327,7 +327,9 @@ def _vehicle_notifications(vehicle: Vehicle) -> list[Any] | None:
 def _notification_recency(notification: Any) -> float:  # noqa: ANN401
     """Sort key for newest-first, safe for null and mixed-tz datetimes."""
     stamp = notification.date
-    return stamp.timestamp() if stamp else float("-inf")
+    # Normally a datetime; guard the rare case where the wrapper yields a plain
+    # date or a string (neither has .timestamp()) so sorting can't raise.
+    return stamp.timestamp() if hasattr(stamp, "timestamp") else float("-inf")
 
 
 def _mask_vin_in_message(message: str | None, vin: str | None) -> str | None:
@@ -353,8 +355,10 @@ def _notification_attributes(vehicle: Vehicle) -> dict[str, Any] | None:
                 "type": n.type,
                 "message": _mask_vin_in_message(n.message, vehicle.vin),
                 # The wrapper only exposes the read *timestamp*; the API's
-                # separate isRead flag can be set without it.
-                "read": n.read is not None or bool(n._data.is_read),  # noqa: SLF001
+                # separate isRead flag can be set without it. getattr guards a
+                # None/absent _data (e.g. a mock or a sparse payload).
+                "read": n.read is not None
+                or bool(getattr(getattr(n, "_data", None), "is_read", False)),
             }
             for n in recent
         ],

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -310,23 +310,41 @@ LAST_SERVICE_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
 NOTIFICATION_ATTRIBUTE_LIMIT = 5
 
 
+def _vehicle_notifications(vehicle: Vehicle) -> list[Any] | None:
+    """The vehicle's notifications, or None when unavailable.
+
+    pytoyoda's ``notifications`` property iterates response payload pages the
+    endpoint model allows to be null (``payload`` and per-page
+    ``notifications``), which raises TypeError on zero-notification accounts —
+    treat that as not-reported.
+    """
+    try:
+        return vehicle.notifications
+    except TypeError:
+        return None
+
+
+def _notification_recency(notification: Any) -> float:  # noqa: ANN401
+    """Sort key for newest-first, safe for null and mixed-tz datetimes."""
+    stamp = notification.date
+    return stamp.timestamp() if stamp else float("-inf")
+
+
 def _mask_vin_in_message(message: str | None, vin: str | None) -> str | None:
     """Mask the vehicle's VIN inside a notification message, if present."""
-    if message and vin and vin in message:
-        return message.replace(vin, mask_string(vin) or "")
+    if message and vin:
+        return message.replace(vin, mask_string(vin))
     return message
 
 
 def _notification_attributes(vehicle: Vehicle) -> dict[str, Any] | None:
     """The most recent notifications; None until the endpoint reports."""
-    notifications = vehicle.notifications
+    notifications = _vehicle_notifications(vehicle)
     if notifications is None:
         return None
-    recent = sorted(
-        notifications,
-        key=lambda n: (n.date is not None, n.date),
-        reverse=True,
-    )[:NOTIFICATION_ATTRIBUTE_LIMIT]
+    recent = sorted(notifications, key=_notification_recency, reverse=True)[
+        :NOTIFICATION_ATTRIBUTE_LIMIT
+    ]
     return {
         "latest": [
             {
@@ -334,11 +352,19 @@ def _notification_attributes(vehicle: Vehicle) -> dict[str, Any] | None:
                 "category": n.category,
                 "type": n.type,
                 "message": _mask_vin_in_message(n.message, vehicle.vin),
-                "read": n.read is not None,
+                # The wrapper only exposes the read *timestamp*; the API's
+                # separate isRead flag can be set without it.
+                "read": n.read is not None or bool(n._data.is_read),  # noqa: SLF001
             }
             for n in recent
         ],
     }
+
+
+def _notification_count(vehicle: Vehicle) -> int | None:
+    """State for the notifications sensor: how many the API returns."""
+    notifications = _vehicle_notifications(vehicle)
+    return None if notifications is None else len(notifications)
 
 
 NOTIFICATIONS_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
@@ -347,9 +373,7 @@ NOTIFICATIONS_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
     icon="mdi:bell-outline",
     entity_category=EntityCategory.DIAGNOSTIC,
     state_class=SensorStateClass.MEASUREMENT,
-    value_fn=lambda vehicle: (
-        None if vehicle.notifications is None else len(vehicle.notifications)
-    ),
+    value_fn=_notification_count,
     attributes_fn=_notification_attributes,
 )
 

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -23,6 +23,7 @@ from .utils import (
     charging_status_key,
     format_statistics_attributes,
     format_vin_sensor_attributes,
+    mask_string,
     round_number,
     td_to_hoursminutes,
 )
@@ -305,6 +306,53 @@ LAST_SERVICE_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
     attributes_fn=_last_service_attributes,
 )
 
+# How many recent notifications to expose as sensor attributes.
+NOTIFICATION_ATTRIBUTE_LIMIT = 5
+
+
+def _mask_vin_in_message(message: str | None, vin: str | None) -> str | None:
+    """Mask the vehicle's VIN inside a notification message, if present."""
+    if message and vin and vin in message:
+        return message.replace(vin, mask_string(vin) or "")
+    return message
+
+
+def _notification_attributes(vehicle: Vehicle) -> dict[str, Any] | None:
+    """The most recent notifications; None until the endpoint reports."""
+    notifications = vehicle.notifications
+    if notifications is None:
+        return None
+    recent = sorted(
+        notifications,
+        key=lambda n: (n.date is not None, n.date),
+        reverse=True,
+    )[:NOTIFICATION_ATTRIBUTE_LIMIT]
+    return {
+        "latest": [
+            {
+                "date": n.date,
+                "category": n.category,
+                "type": n.type,
+                "message": _mask_vin_in_message(n.message, vehicle.vin),
+                "read": n.read is not None,
+            }
+            for n in recent
+        ],
+    }
+
+
+NOTIFICATIONS_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
+    key="notifications",
+    translation_key="notifications",
+    icon="mdi:bell-outline",
+    entity_category=EntityCategory.DIAGNOSTIC,
+    state_class=SensorStateClass.MEASUREMENT,
+    value_fn=lambda vehicle: (
+        None if vehicle.notifications is None else len(vehicle.notifications)
+    ),
+    attributes_fn=_notification_attributes,
+)
+
 STATISTICS_ENTITY_DESCRIPTIONS_DAILY = ToyotaStatisticsSensorEntityDescription(
     key="current_day_statistics",
     translation_key="current_day_statistics",
@@ -458,6 +506,14 @@ def create_sensor_configurations(metric_values: bool) -> list[dict[str, Any]]:  
                 "service_history",
                 False,
             ),
+            "native_unit": None,
+            "suggested_unit": None,
+        },
+        {
+            "description": NOTIFICATIONS_ENTITY_DESCRIPTION,
+            # pytoyoda fetches notifications unconditionally (no capability
+            # flag); an unreported endpoint reads as unknown.
+            "capability_check": lambda v: True,  # noqa : ARG005
             "native_unit": None,
             "suggested_unit": None,
         },

--- a/custom_components/toyota/translations/en.json
+++ b/custom_components/toyota/translations/en.json
@@ -150,6 +150,9 @@
       },
       "last_service": {
         "name": "Last service"
+      },
+      "notifications": {
+        "name": "Notifications"
       }
     },
     "button": {


### PR DESCRIPTION
## What
Adds a diagnostic count sensor for the notifications endpoint pytoyoda already fetches — zero additional API traffic. State = number of notifications the API returns; the 5 most recent (date/category/type/message/read) are exposed as attributes, with the vehicle's VIN masked inside message text before it reaches the recorder.

## Why
Gives HA visibility into what the MyToyota app is pushing (remote-command results, alerts) without polling anything new.

## Hardening notes
- `vehicle.notifications` is guarded: the endpoint models allow a null `payload` / per-page `notifications` list, which makes the pytoyoda property raise `TypeError` on zero-notification accounts — treated as unknown here. Happy to also fix that upstream in pytoyoda.
- Recency sort uses an epoch key so null or mixed naive/aware datetimes can't raise.
- `read` honors the API's `isRead` flag alongside the read timestamp.

## Tested
Live on a Corolla TS (EU), 58 notifications: count + latest-5 attributes populate, VIN masked (`************22886: Climate is now stopped`). Ruff/pre-commit clean.