### PR TITLE
feat: recent-trips sensor with rolling per-VIN cache, on-stop refill and lazy route service

### DIFF
--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -1118,7 +1118,9 @@ async def _async_register_trips_services(hass: HomeAssistant) -> None:  # noqa: 
                     )
             # Trigger a coordinator refresh so the sensor's state reflects
             # the new cache contents on the next tick.
-            hass.async_create_task(coord.async_request_refresh())
+            hass.async_create_background_task(
+                coord.async_request_refresh(), "toyota_recent_trips_refresh"
+            )
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -931,6 +931,13 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
 
     await coordinator.async_config_entry_first_refresh()
 
+    # Prune cached trips for VINs that are no longer on the account.
+    if coordinator.data:
+        known_vins = [
+            vd["data"].vin for vd in coordinator.data if vd.get("data") is not None
+        ]
+        await trips_manager.async_prune_orphans(known_vins)
+
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -117,7 +117,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable
 
     from homeassistant.config_entries import ConfigEntry
-    from homeassistant.core import HomeAssistant, ServiceCall
+    from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse
     from pytoyoda.models.summary import Summary
     from pytoyoda.models.vehicle import Vehicle
 
@@ -953,6 +953,8 @@ SERVICE_REFRESH_VEHICLE_STATUS = "refresh_vehicle_status"
 ATTR_TIMEOUT_SECONDS = "timeout_seconds"
 SERVICE_REFRESH_RECENT_TRIPS = "refresh_recent_trips"
 ATTR_LIMIT = "limit"
+SERVICE_GET_TRIP_ROUTE = "get_trip_route"
+ATTR_TRIP_ID = "trip_id"
 
 
 def _resolve_devices_to_vins_per_entry(
@@ -1121,6 +1123,54 @@ async def _async_register_services(hass: HomeAssistant) -> None:  # noqa: C901
         SERVICE_REFRESH_RECENT_TRIPS,
         _handle_refresh_recent_trips,
     )
+
+    if not hass.services.has_service(DOMAIN, SERVICE_GET_TRIP_ROUTE):
+        from homeassistant.core import SupportsResponse  # noqa: PLC0415
+
+        async def _handle_get_trip_route(call: ServiceCall) -> ServiceResponse:
+            """Return the cached route polyline for a single trip by id.
+
+            Read-only lookup against the per-entry trips cache. The card
+            calls this lazily when the user navigates to a trip - keeps
+            sensor.<alias>_recent_trips's `attributes.trips` payload
+            small (no per-trip polyline) so the recorder, state machine,
+            and WebSocket subscribers don't carry the bulk on every
+            cache mutation. Mirrors HA core's 2024.x weather-forecast
+            shape (state stays small; bulk fetched on demand).
+            """
+            raw = call.data.get("device_id") or []
+            device_ids: list[str] = [raw] if isinstance(raw, str) else list(raw)
+            trip_id = str(call.data.get(ATTR_TRIP_ID) or "").strip()
+            if not device_ids or not trip_id:
+                _LOGGER.warning(
+                    "toyota.get_trip_route called with missing device or "
+                    "trip_id (devices=%s, trip_id=%r)",
+                    device_ids,
+                    trip_id,
+                )
+                return {"found": False, "route": []}
+
+            per_entry_vins = _resolve_devices_to_vins_per_entry(hass, device_ids)
+            for entry_id, vins in per_entry_vins.items():
+                mgr = hass.data[DOMAIN].get(f"{entry_id}_trips_manager")
+                if mgr is None:
+                    continue
+                for vin in vins:
+                    for trip in mgr.cache.get(vin):
+                        if str(trip.get("id")) == trip_id:
+                            return {
+                                "found": True,
+                                "trip_id": trip_id,
+                                "route": list(trip.get("route") or []),
+                            }
+            return {"found": False, "trip_id": trip_id, "route": []}
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_GET_TRIP_ROUTE,
+            _handle_get_trip_route,
+            supports_response=SupportsResponse.ONLY,
+        )
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -668,8 +668,7 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
         # No-op when CONF_MAX_RECENT_TRIPS is 0 (default). Independent of
         # the /status decision; uses the same trigger info so we fetch trips
         # only on stop-event ticks (just_stopped + conditional followup).
-        if vin:
-            await trips_manager.async_maybe_refresh(vehicle, vin, decision)
+        await trips_manager.async_maybe_refresh(vehicle, vin, decision)
 
         # Movement / sensor state.
         car_currently_moving = (
@@ -989,7 +988,7 @@ def _resolve_devices_to_vins_per_entry(
     return per_entry_vins
 
 
-async def _async_register_services(hass: HomeAssistant) -> None:  # noqa: C901
+async def _async_register_services(hass: HomeAssistant) -> None:
     """Register the toyota.refresh_vehicle_status service exactly once.
 
     Service handlers resolve their target devices to VINs via the device
@@ -1042,6 +1041,11 @@ async def _async_register_services(hass: HomeAssistant) -> None:  # noqa: C901
         _handle_refresh_vehicle_status,
     )
 
+    await _async_register_trips_services(hass)
+
+
+async def _async_register_trips_services(hass: HomeAssistant) -> None:  # noqa: C901
+    """Register the recent-trips services exactly once."""
     if hass.services.has_service(DOMAIN, SERVICE_REFRESH_RECENT_TRIPS):
         return
 
@@ -1054,9 +1058,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:  # noqa: C901
         raw = call.data.get("device_id") or []
         device_ids: list[str] = [raw] if isinstance(raw, str) else list(raw)
         if not device_ids:
-            _LOGGER.warning(
-                "toyota.refresh_recent_trips called with no device target"
-            )
+            _LOGGER.warning("toyota.refresh_recent_trips called with no device target")
             return
         try:
             limit = int(call.data.get(ATTR_LIMIT, 0))

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -29,6 +29,7 @@ from .const import (
     CONF_FAILED_WAKE_THRESHOLD,
     CONF_IDLE_WAKE_HOURS,
     CONF_MAX_CACHE_AGE_MINUTES,
+    CONF_MAX_RECENT_TRIPS,
     CONF_METRIC_VALUES,
     CONF_POLLING_INTERVAL_MINUTES,
     CONF_POST_COUNT_PER_STOP,
@@ -38,6 +39,7 @@ from .const import (
     DEFAULT_FAILED_WAKE_THRESHOLD,
     DEFAULT_IDLE_WAKE_HOURS,
     DEFAULT_MAX_CACHE_AGE_MINUTES,
+    DEFAULT_MAX_RECENT_TRIPS,
     DEFAULT_POLLING_INTERVAL_MINUTES,
     DEFAULT_POST_COUNT_PER_STOP,
     DEFAULT_RETAIN_ON_TRANSIENT_FAILURE,
@@ -58,6 +60,7 @@ from .refresh_strategy import (
     on_post_layer1_success,
     on_wake_failed,
 )
+from .trips_manager import RecentTripsManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -229,6 +232,9 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
     )
     post_count_per_stop: int = entry.options.get(
         CONF_POST_COUNT_PER_STOP, DEFAULT_POST_COUNT_PER_STOP
+    )
+    max_recent_trips: int = int(
+        entry.options.get(CONF_MAX_RECENT_TRIPS, DEFAULT_MAX_RECENT_TRIPS)
     )
     # Persist per-VIN state in hass.data so it survives config entry reload
     # (options flow triggers a reload, which would otherwise recreate these as
@@ -658,6 +664,13 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
         if vin:
             _persist_status_for_cache(vehicle, vin)
 
+        # Phase 2b: recent-trips manager.
+        # No-op when CONF_MAX_RECENT_TRIPS is 0 (default). Independent of
+        # the /status decision; uses the same trigger info so we fetch trips
+        # only on stop-event ticks (just_stopped + conditional followup).
+        if vin:
+            await trips_manager.async_maybe_refresh(vehicle, vin, decision)
+
         # Movement / sensor state.
         car_currently_moving = (
             state.last_odometer_km is not None
@@ -885,6 +898,14 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
         _LOGGER.debug(vehicle_informations)
         return vehicle_informations
 
+    # Recent-trips manager. Lives alongside the coordinator (not part of it)
+    # because the trips data lifecycle is decoupled from the cycle's
+    # /status work. Cache survives HA restart via Store; auto-fetch is gated
+    # on max_recent_trips > 0 + smart-strategy stop triggers.
+    trips_manager = RecentTripsManager(hass, entry, max_recent_trips)
+    await trips_manager.async_setup()
+    hass.data[DOMAIN][f"{entry.entry_id}_trips_manager"] = trips_manager
+
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
@@ -923,6 +944,8 @@ async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0
 
 SERVICE_REFRESH_VEHICLE_STATUS = "refresh_vehicle_status"
 ATTR_TIMEOUT_SECONDS = "timeout_seconds"
+SERVICE_REFRESH_RECENT_TRIPS = "refresh_recent_trips"
+ATTR_LIMIT = "limit"
 
 
 def _resolve_devices_to_vins_per_entry(
@@ -957,7 +980,7 @@ def _resolve_devices_to_vins_per_entry(
     return per_entry_vins
 
 
-async def _async_register_services(hass: HomeAssistant) -> None:
+async def _async_register_services(hass: HomeAssistant) -> None:  # noqa: C901
     """Register the toyota.refresh_vehicle_status service exactly once.
 
     Service handlers resolve their target devices to VINs via the device
@@ -1010,6 +1033,88 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         _handle_refresh_vehicle_status,
     )
 
+    if hass.services.has_service(DOMAIN, SERVICE_REFRESH_RECENT_TRIPS):
+        return
+
+    async def _handle_refresh_recent_trips(call: ServiceCall) -> None:
+        """Discard the cached trips for the targeted VINs and refetch limit=N.
+
+        Works regardless of CONF_MAX_RECENT_TRIPS (so users with auto-fetch
+        disabled can drive on-demand fetches via daily automations).
+        """
+        raw = call.data.get("device_id") or []
+        device_ids: list[str] = [raw] if isinstance(raw, str) else list(raw)
+        if not device_ids:
+            _LOGGER.warning(
+                "toyota.refresh_recent_trips called with no device target"
+            )
+            return
+        try:
+            limit = int(call.data.get(ATTR_LIMIT, 0))
+        except (TypeError, ValueError):
+            _LOGGER.warning(
+                "toyota.refresh_recent_trips: invalid limit value %r",
+                call.data.get(ATTR_LIMIT),
+            )
+            return
+        if not 1 <= limit <= 50:  # noqa: PLR2004
+            _LOGGER.warning(
+                "toyota.refresh_recent_trips: limit must be 1..50, got %s",
+                limit,
+            )
+            return
+        _LOGGER.info(
+            "toyota.refresh_recent_trips invoked for devices=%s (limit=%d)",
+            device_ids,
+            limit,
+        )
+        per_entry_vins = _resolve_devices_to_vins_per_entry(hass, device_ids)
+        for entry_id, vins in per_entry_vins.items():
+            mgr = hass.data[DOMAIN].get(f"{entry_id}_trips_manager")
+            coord = hass.data[DOMAIN].get(entry_id)
+            if mgr is None or coord is None or coord.data is None:
+                continue
+            # Find each VIN's Vehicle object inside the most recent
+            # coordinator data. We need the live Vehicle (with auth + api)
+            # to issue get_recent_trips, not just the stored trip dicts.
+            for vin in vins:
+                vehicle = next(
+                    (
+                        vd["data"]
+                        for vd in coord.data
+                        if vd.get("data") is not None and vd["data"].vin == vin
+                    ),
+                    None,
+                )
+                if vehicle is None:
+                    _LOGGER.warning(
+                        "toyota.refresh_recent_trips: VIN ...%s not in "
+                        "coordinator data; skipping",
+                        vin[-6:],
+                    )
+                    continue
+                try:
+                    count = await mgr.async_service_refresh(vin, vehicle, limit)
+                    _LOGGER.info(
+                        "toyota.refresh_recent_trips vin=...%s -> %d trips",
+                        vin[-6:],
+                        count,
+                    )
+                except Exception:
+                    _LOGGER.exception(
+                        "toyota.refresh_recent_trips failed for vin=...%s",
+                        vin[-6:],
+                    )
+            # Trigger a coordinator refresh so the sensor's state reflects
+            # the new cache contents on the next tick.
+            hass.async_create_task(coord.async_request_refresh())
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REFRESH_RECENT_TRIPS,
+        _handle_refresh_recent_trips,
+    )
+
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload the integration when options change so the new toggle takes effect."""
@@ -1022,5 +1127,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
+        # Drop the trips manager too. The cache is on disk and survives;
+        # the diag bucket intentionally stays in hass.data so per-VIN
+        # state survives a reload (matches the existing pattern).
+        hass.data[DOMAIN].pop(f"{entry.entry_id}_trips_manager", None)
 
     return unload_ok

--- a/custom_components/toyota/button.py
+++ b/custom_components/toyota/button.py
@@ -11,8 +11,16 @@ from typing import TYPE_CHECKING
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 
-from .const import DOMAIN
+from .const import (
+    CONF_MAX_RECENT_TRIPS,
+    DEFAULT_MAX_RECENT_TRIPS,
+    DOMAIN,
+)
 from .entity import ToyotaBaseEntity
+
+# Default fetch size for the manual button when auto-fetch is off
+# (max_recent_trips=0). Picked as a sensible "show me the last few drives".
+_BUTTON_LIMIT_FALLBACK = 5
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -30,6 +38,13 @@ REFRESH_BUTTON_DESCRIPTION = ButtonEntityDescription(
     icon="mdi:refresh-circle",
 )
 
+REFRESH_RECENT_TRIPS_BUTTON_DESCRIPTION = ButtonEntityDescription(
+    key="refresh_recent_trips",
+    translation_key="refresh_recent_trips",
+    name="Refresh recent trips",
+    icon="mdi:refresh-auto",
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -40,15 +55,25 @@ async def async_setup_entry(
     coordinator: DataUpdateCoordinator[list[VehicleData]] = hass.data[DOMAIN][
         entry.entry_id
     ]
-    async_add_entities(
-        ToyotaRefreshStatusButton(
-            coordinator=coordinator,
-            entry_id=entry.entry_id,
-            vehicle_index=index,
-            description=REFRESH_BUTTON_DESCRIPTION,
+    buttons: list[ButtonEntity] = []
+    for index in range(len(coordinator.data)):
+        buttons.append(
+            ToyotaRefreshStatusButton(
+                coordinator=coordinator,
+                entry_id=entry.entry_id,
+                vehicle_index=index,
+                description=REFRESH_BUTTON_DESCRIPTION,
+            )
         )
-        for index in range(len(coordinator.data))
-    )
+        buttons.append(
+            ToyotaRefreshRecentTripsButton(
+                coordinator=coordinator,
+                entry_id=entry.entry_id,
+                vehicle_index=index,
+                description=REFRESH_RECENT_TRIPS_BUTTON_DESCRIPTION,
+            )
+        )
+    async_add_entities(buttons)
 
 
 class ToyotaRefreshStatusButton(ToyotaBaseEntity, ButtonEntity):
@@ -68,5 +93,41 @@ class ToyotaRefreshStatusButton(ToyotaBaseEntity, ButtonEntity):
             DOMAIN,
             "refresh_vehicle_status",
             {"device_id": [device.id]},
+            blocking=False,
+        )
+
+
+class ToyotaRefreshRecentTripsButton(ToyotaBaseEntity, ButtonEntity):
+    """One-tap wrapper around toyota.refresh_recent_trips for one VIN.
+
+    Limit defaults to the user's max_recent_trips when set; falls back to
+    _BUTTON_LIMIT_FALLBACK (5) when auto-fetch is disabled (max=0). Users
+    who want a different one-tap fetch size should use the service call
+    with an explicit ``limit`` field.
+    """
+
+    async def async_press(self) -> None:
+        """Fire toyota.refresh_recent_trips for this vehicle's device."""
+        from homeassistant.helpers import device_registry as dr  # noqa: PLC0415
+
+        device_reg = dr.async_get(self.hass)
+        device = device_reg.async_get_device(
+            identifiers={(DOMAIN, self.vehicle.vin or "")}
+        )
+        if device is None:
+            return
+        # Resolve the limit from the config entry's options. self.coordinator
+        # exposes its config entry via the standard HA pattern.
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        max_trips = int(
+            entry.options.get(CONF_MAX_RECENT_TRIPS, DEFAULT_MAX_RECENT_TRIPS)
+            if entry is not None
+            else DEFAULT_MAX_RECENT_TRIPS
+        )
+        limit = max_trips if max_trips > 0 else _BUTTON_LIMIT_FALLBACK
+        await self.hass.services.async_call(
+            DOMAIN,
+            "refresh_recent_trips",
+            {"device_id": [device.id], "limit": limit},
             blocking=False,
         )

--- a/custom_components/toyota/config_flow.py
+++ b/custom_components/toyota/config_flow.py
@@ -25,6 +25,7 @@ from .const import (
     CONF_FAILED_WAKE_THRESHOLD,
     CONF_IDLE_WAKE_HOURS,
     CONF_MAX_CACHE_AGE_MINUTES,
+    CONF_MAX_RECENT_TRIPS,
     CONF_METRIC_VALUES,
     CONF_POLLING_INTERVAL_MINUTES,
     CONF_POST_COUNT_PER_STOP,
@@ -33,10 +34,12 @@ from .const import (
     DEFAULT_FAILED_WAKE_THRESHOLD,
     DEFAULT_IDLE_WAKE_HOURS,
     DEFAULT_MAX_CACHE_AGE_MINUTES,
+    DEFAULT_MAX_RECENT_TRIPS,
     DEFAULT_POLLING_INTERVAL_MINUTES,
     DEFAULT_POST_COUNT_PER_STOP,
     DEFAULT_RETAIN_ON_TRANSIENT_FAILURE,
     DOMAIN,
+    MAX_RECENT_TRIPS_LIMIT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -284,6 +287,20 @@ class ToyotaOptionsFlow(config_entries.OptionsFlow):
                     ): selector.NumberSelector(
                         selector.NumberSelectorConfig(
                             min=1, max=5, step=1, mode=selector.NumberSelectorMode.BOX
+                        )
+                    ),
+                    vol.Required(
+                        CONF_MAX_RECENT_TRIPS,
+                        default=opts.get(
+                            CONF_MAX_RECENT_TRIPS,
+                            DEFAULT_MAX_RECENT_TRIPS,
+                        ),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=0,
+                            max=MAX_RECENT_TRIPS_LIMIT,
+                            step=1,
+                            mode=selector.NumberSelectorMode.BOX,
                         )
                     ),
                 }

--- a/custom_components/toyota/const.py
+++ b/custom_components/toyota/const.py
@@ -57,6 +57,17 @@ DEFAULT_POLLING_INTERVAL_MINUTES = 6
 CONF_POST_COUNT_PER_STOP = "post_count_per_stop"
 DEFAULT_POST_COUNT_PER_STOP = 2
 
+# Recent-trips sensor: rolling cache of the most recent N trips per vehicle,
+# fetched on-demand when the smart-strategy detects a stop event. Surfaces as
+# `sensor.<alias>_recent_trips` with attributes.trips[] in the
+# journey-viewer-card data contract shape. 0 (default) disables the feature
+# entirely (no extra API calls). 1-20 enables auto-fetch + caches that many
+# most-recent trips per VIN. The service `toyota.refresh_recent_trips` works
+# regardless of this setting.
+CONF_MAX_RECENT_TRIPS = "max_recent_trips"
+DEFAULT_MAX_RECENT_TRIPS = 0
+MAX_RECENT_TRIPS_LIMIT = 20
+
 # DEFAULTS
 DEFAULT_LOCALE = "en-gb"
 

--- a/custom_components/toyota/entity.py
+++ b/custom_components/toyota/entity.py
@@ -37,6 +37,7 @@ class ToyotaBaseEntity(CoordinatorEntity):
         super().__init__(coordinator)  # type: ignore[reportArgumentType, arg-type]
 
         self.index = vehicle_index
+        self._entry_id = entry_id
         self.entity_description = description
         self.vehicle: Vehicle = coordinator.data[self.index]["data"]
         self.statistics: StatisticsData | None = coordinator.data[self.index][

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -600,6 +600,77 @@ class ToyotaStatisticsSensor(ToyotaBaseEntity, SensorEntity):
         )
 
 
+RECENT_TRIPS_ENTITY_DESCRIPTION = SensorEntityDescription(
+    key="recent_trips",
+    translation_key="recent_trips",
+    icon="mdi:road-variant",
+)
+
+
+class ToyotaRecentTripsSensor(ToyotaBaseEntity, SensorEntity):
+    """Sensor exposing the recent-trips rolling cache for one VIN.
+
+    State: count of trips currently in the cache (0 when disabled or not
+    yet seeded). Attributes:
+
+    - ``trips``: list of trip dicts in journey-viewer-card data contract shape
+    - ``last_trip_label``: human-readable label for the most recent trip
+      (convenience for templates that don't want to parse the array)
+    - ``source``: ``"toyota"`` (cosmetic, for cards that group by source)
+
+    Sensor reads from the manager's cache on every coordinator update.
+    Cache mutations happen during _refresh_one_vehicle (in the coordinator's
+    update path), so the next coordinator-driven sensor refresh sees fresh
+    state automatically.
+    """
+
+    @property
+    def available(self) -> bool:
+        """Available once the manager exists; cache being empty is a valid state."""
+        if not super().available:
+            return False
+        mgr = self.hass.data.get(DOMAIN, {}).get(f"{self._entry_id}_trips_manager")
+        return mgr is not None
+
+    @property
+    def native_value(self) -> StateType:
+        """Number of trips currently cached for this VIN."""
+        mgr = self.hass.data.get(DOMAIN, {}).get(f"{self._entry_id}_trips_manager")
+        if mgr is None:
+            return None
+        vin = getattr(self.vehicle, "vin", None)
+        if not vin:
+            return None
+        return len(mgr.cache.get(vin))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose the cached trips list and a convenience label."""
+        mgr = self.hass.data.get(DOMAIN, {}).get(f"{self._entry_id}_trips_manager")
+        if mgr is None:
+            return None
+        vin = getattr(self.vehicle, "vin", None)
+        if not vin:
+            return None
+        trips = mgr.cache.get(vin)
+        last_trip_label: str | None = None
+        if trips:
+            first = trips[0]
+            stats = first.get("stats", {})
+            ts = first.get("start_ts") or "?"
+            distance_m = stats.get("distance_m")
+            if isinstance(distance_m, (int, float)):
+                distance_str = f"{distance_m / 1000:.2f} km"
+            else:
+                distance_str = "?"
+            last_trip_label = f"{ts} ({distance_str})"
+        return {
+            "trips": trips,
+            "last_trip_label": last_trip_label,
+            "source": "toyota",
+        }
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -661,6 +732,18 @@ async def async_setup_entry(
                 LAST_ERROR_CODE_ENTITY_DESCRIPTION,
                 STATUS_LAST_REPORTED_ENTITY_DESCRIPTION,
                 STATUS_REFRESH_STATE_ENTITY_DESCRIPTION,
+            )
+        )
+
+        # Recent-trips sensor: always created (so users discover the entity);
+        # state reads "0 trips" when CONF_MAX_RECENT_TRIPS=0 and no service
+        # call has been used to seed it.
+        sensors.append(
+            ToyotaRecentTripsSensor(
+                coordinator=coordinator,
+                entry_id=entry.entry_id,
+                vehicle_index=index,
+                description=RECENT_TRIPS_ENTITY_DESCRIPTION,
             )
         )
 

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -645,11 +645,20 @@ class ToyotaRecentTripsSensor(ToyotaBaseEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
-        """Expose the cached trips list and a convenience label.
+        """Expose cached trip metadata WITHOUT route polylines.
 
-        Payload size scales with max_recent_trips x route polyline length.
-        With long routes and max=20 the attribute can cross HA's 16 KiB soft
-        warning; lower max_recent_trips if the recorder complains.
+        Each trip dict in the returned ``trips`` list has its ``route``
+        field stripped and replaced with a ``route_point_count`` integer
+        so callers can decide whether to fetch the full route via the
+        ``toyota.get_trip_route`` service. Stripping the route keeps the
+        attribute payload small (~6 KB for 10 trips vs ~640 KB with
+        polylines for a daily-driver) so the HA recorder, state machine,
+        and WebSocket pipeline don't carry per-cycle bulk. Mirrors HA
+        core's 2024.x weather-forecast pattern: state stays small; bulk
+        data fetched on demand.
+
+        The journey-viewer-card lazy-loads route per trip via the
+        service when the user navigates to a trip.
         """
         mgr = self.hass.data.get(DOMAIN, {}).get(f"{self._entry_id}_trips_manager")
         if mgr is None:
@@ -658,6 +667,7 @@ class ToyotaRecentTripsSensor(ToyotaBaseEntity, SensorEntity):
         if not vin:
             return None
         trips = mgr.cache.get(vin)
+        slim_trips = [_strip_route(t) for t in trips]
         last_trip_label: str | None = None
         if trips:
             first = trips[0]
@@ -670,10 +680,24 @@ class ToyotaRecentTripsSensor(ToyotaBaseEntity, SensorEntity):
                 distance_str = "?"
             last_trip_label = f"{ts} ({distance_str})"
         return {
-            "trips": trips,
+            "trips": slim_trips,
             "last_trip_label": last_trip_label,
             "source": "toyota",
         }
+
+
+def _strip_route(trip: dict) -> dict:
+    """Return a shallow copy of ``trip`` with ``route`` removed.
+
+    Replaces ``route`` with an integer ``route_point_count`` so callers
+    can decide whether to lazy-load the route via the get_trip_route
+    service. Other fields (id, start/end, stats, behaviours, scores)
+    are passed through unchanged.
+    """
+    route = trip.get("route") or []
+    out = {k: v for k, v in trip.items() if k != "route"}
+    out["route_point_count"] = len(route)
+    return out
 
 
 async def async_setup_entry(

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -645,7 +645,12 @@ class ToyotaRecentTripsSensor(ToyotaBaseEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
-        """Expose the cached trips list and a convenience label."""
+        """Expose the cached trips list and a convenience label.
+
+        Payload size scales with max_recent_trips x route polyline length.
+        With long routes and max=20 the attribute can cross HA's 16 KiB soft
+        warning; lower max_recent_trips if the recorder complains.
+        """
         mgr = self.hass.data.get(DOMAIN, {}).get(f"{self._entry_id}_trips_manager")
         if mgr is None:
             return None

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -671,7 +671,7 @@ class ToyotaRecentTripsSensor(ToyotaBaseEntity, SensorEntity):
         last_trip_label: str | None = None
         if trips:
             first = trips[0]
-            stats = first.get("stats", {})
+            stats = first.get("stats") or {}
             ts = first.get("start_ts") or "?"
             distance_m = stats.get("distance_m")
             if isinstance(distance_m, (int, float)):

--- a/custom_components/toyota/services.yaml
+++ b/custom_components/toyota/services.yaml
@@ -27,3 +27,36 @@ refresh_vehicle_status:
           max: 180
           step: 5
           unit_of_measurement: s
+
+refresh_recent_trips:
+  name: Refresh recent trips
+  description: >
+    Fetch the most recent N trips for the targeted vehicle and replace the
+    per-vehicle 'Recent trips' sensor cache. Each call is one API request to
+    /v1/trips with route data (a heavier payload than the standard cycle's
+    summary-only call). Recommended use cases: a daily automation that fetches
+    a fresh batch when max_recent_trips=0 (auto-fetch disabled), or a one-off
+    cache refresh after changing max_recent_trips. Works regardless of
+    max_recent_trips, so you can keep auto-fetch off and drive everything via
+    automations.
+  fields:
+    device_id:
+      name: Vehicle
+      description: The Toyota vehicle whose recent-trips cache to refresh.
+      required: true
+      selector:
+        device:
+          integration: toyota
+    limit:
+      name: Limit
+      description: >
+        How many recent trips to fetch (1-50, Toyota API maximum). The cache
+        is fully replaced - existing cached trips are discarded before the
+        new batch is stored.
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 50
+          step: 1
+          mode: box

--- a/custom_components/toyota/services.yaml
+++ b/custom_components/toyota/services.yaml
@@ -60,3 +60,30 @@ refresh_recent_trips:
           max: 50
           step: 1
           mode: box
+
+get_trip_route:
+  name: Get trip route
+  description: >
+    Return the cached GPS route polyline for a single trip by id. Used by
+    the journey-viewer-card to lazy-load route data per trip rather than
+    receiving every cached trip's route in the sensor's state attributes
+    (where with_route polylines for long drives can run hundreds of KB and
+    overwhelm the recorder + state-machine + WebSocket pipeline).
+    Read-only: does not call the Toyota API. The cache is populated by the
+    smart-strategy stop-event lifecycle and the refresh_recent_trips service.
+  fields:
+    device_id:
+      name: Vehicle
+      description: The Toyota vehicle whose trips cache to read.
+      required: true
+      selector:
+        device:
+          integration: toyota
+    trip_id:
+      name: Trip ID
+      description: >
+        UUID of the trip whose route to return. Match the `id` field on
+        any item in the recent_trips sensor's `trips` attribute.
+      required: true
+      selector:
+        text:

--- a/custom_components/toyota/translations/en.json
+++ b/custom_components/toyota/translations/en.json
@@ -28,7 +28,8 @@
           "idle_wake_hours": "Wake idle vehicle every N hours (0 = disabled)",
           "failed_wake_threshold": "Mark unreachable after N failed wakes",
           "max_cache_age_minutes": "Refresh status cache if older",
-          "post_count_per_stop": "Wake POSTs per stop event"
+          "post_count_per_stop": "Wake POSTs per stop event",
+          "max_recent_trips": "Recent trips to keep in cache (0 = disabled)"
         },
         "data_description": {
           "polling_interval_minutes": "How often the integration polls Toyota for fresh data (5-60 minutes; default 6). Lower values may hit rate limits.",
@@ -37,7 +38,8 @@
           "idle_wake_hours": "Wake the car periodically even if it has not moved. Useful for cars that sit unused for days where you still want fresh lock state. 0 (default) disables this entirely; 1-72 = wake every N hours. Each wake costs cellular airtime and a small amount of 12 V battery. Note: the wake only refreshes the /v1/global/remote/status endpoint (door, window, lock and hood state). Other data (odometer, fuel, location, etc.) is fetched on every cycle independently and does not need a wake.",
           "failed_wake_threshold": "If a vehicle stops responding to wake requests this many times in a row, it is marked unreachable per-VIN until it shows any sign of life (driving event, external app refresh, manual service call). Default 3.",
           "max_cache_age_minutes": "Maximum acceptable age of the cached status data before issuing a fresh GET (5-180 minutes; default 30). Note: this controls only the /v1/global/remote/status endpoint, which carries door, window, lock and hood state. Other data (odometer, fuel, location, etc.) is fetched on every cycle independently.",
-          "post_count_per_stop": "How many wake POSTs to fire when the vehicle is detected as just-stopped, one per coordinator cycle. 1 = single POST. 2 (default) = an additional POST on the next cycle, which typically catches state the user changes shortly after stopping (locking the doors, opening the trunk, etc.) - those events trigger fresh modem reports that the second POST's poll loop picks up. Higher values rarely help and burn 12 V battery."
+          "post_count_per_stop": "How many wake POSTs to fire when the vehicle is detected as just-stopped, one per coordinator cycle. 1 = single POST. 2 (default) = an additional POST on the next cycle, which typically catches state the user changes shortly after stopping (locking the doors, opening the trunk, etc.) - those events trigger fresh modem reports that the second POST's poll loop picks up. Higher values rarely help and burn 12 V battery.",
+          "max_recent_trips": "Populates a per-vehicle 'Recent trips' sensor with the last N trips (route waypoints + per-trip stats), suitable for journey-viewer custom cards. 0 (default) disables auto-fetch entirely (no extra API calls). 1-20 enables auto-fetch on stop events; the cache survives HA restart. The toyota.refresh_recent_trips service and the per-vehicle 'Refresh recent trips' button work regardless of this setting, so you can keep auto-fetch off and drive fetches via daily automations."
         }
       }
     }
@@ -59,6 +61,9 @@
     "sensor": {
       "vin": {
         "name": "Vehicle-Identify-Number"
+      },
+      "recent_trips": {
+        "name": "Recent trips"
       },
       "odometer": {
         "name": "Odometer"
@@ -147,6 +152,9 @@
     "button": {
       "refresh_vehicle_status": {
         "name": "Refresh vehicle status"
+      },
+      "refresh_recent_trips": {
+        "name": "Refresh recent trips"
       }
     },
     "binary_sensor": {

--- a/custom_components/toyota/trips_cache.py
+++ b/custom_components/toyota/trips_cache.py
@@ -1,0 +1,108 @@
+"""Persistent rolling-window cache of recent trips per vehicle.
+
+Backed by Home Assistant's Store helper, which serialises to JSON under
+``.storage/<key>.json`` with atomic writes. One file per config entry,
+structured as ``{vin: [trip_dict, ...]}`` where each trip_dict is in the
+journey-viewer-card data contract shape (post-transform from pytoyoda's
+_TripModel).
+
+The cache survives HA restarts so the dashboard shows trips immediately
+on boot rather than waiting for the next drive's smart-refresh tick.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.storage import Store
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+CACHE_VERSION = 1
+CACHE_KEY_PREFIX = "toyota.trips_cache"
+
+
+class TripsCacheStore:
+    """Per-config-entry rolling cache of recent trips, indexed by VIN.
+
+    Trips are stored in card-shape (post-transform). Identity is the trip's
+    Toyota-issued ``id`` field, verified empirically stable across fetches
+    in pre-flight task 0c (UUIDs do not change between calls).
+    """
+
+    def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        """Bind the store to a specific config entry's filesystem slot."""
+        self._store: Store[dict[str, list[dict]]] = Store(
+            hass, version=CACHE_VERSION, key=f"{CACHE_KEY_PREFIX}.{entry_id}"
+        )
+        self._data: dict[str, list[dict]] = {}
+        self._loaded: bool = False
+
+    async def load(self) -> None:
+        """Read the cache from disk. Idempotent; safe to call repeatedly."""
+        raw = await self._store.async_load()
+        self._data = raw if isinstance(raw, dict) else {}
+        self._loaded = True
+
+    async def save(self) -> None:
+        """Persist the cache to disk. Caller is responsible for batching."""
+        await self._store.async_save(self._data)
+
+    @property
+    def loaded(self) -> bool:
+        """True once load() has completed at least once."""
+        return self._loaded
+
+    def get(self, vin: str) -> list[dict]:
+        """Return the cached trips for one VIN, or [] if uninitialised."""
+        return list(self._data.get(vin, []))
+
+    def set(self, vin: str, trips: list[dict]) -> None:
+        """Replace the cached trips for one VIN.
+
+        Caller is responsible for ordering (most-recent-first by convention)
+        and for trimming to ``max_size`` before calling. ``save()`` must be
+        called separately to persist.
+        """
+        self._data[vin] = list(trips)
+
+    def append(self, vin: str, trip: dict, max_size: int) -> None:
+        """Prepend a new trip to the front (most-recent-first), trim to max_size.
+
+        No-op if the trip's ``id`` is already in the cache (idempotent;
+        protects against double-fetches on retry paths).
+        """
+        if max_size <= 0:
+            return
+        existing = self._data.get(vin, [])
+        trip_id = trip.get("id")
+        if trip_id is not None and any(t.get("id") == trip_id for t in existing):
+            return
+        # Prepend the new trip, trim the tail.
+        self._data[vin] = ([trip, *existing])[:max_size]
+
+    def trim(self, vin: str, max_size: int) -> None:
+        """Trim the cached list for one VIN to the first ``max_size`` entries.
+
+        Used when ``max_recent_trips`` is lowered via the options flow.
+        """
+        if max_size <= 0:
+            self._data.pop(vin, None)
+            return
+        existing = self._data.get(vin)
+        if existing is None:
+            return
+        self._data[vin] = existing[:max_size]
+
+    def has_trip_id(self, vin: str, trip_id: str) -> bool:
+        """Return True if any cached trip for VIN has the given id."""
+        return any(t.get("id") == trip_id for t in self._data.get(vin, []))
+
+    def clear(self, vin: str) -> None:
+        """Drop the entry for one VIN (used by the service call before refetch)."""
+        self._data.pop(vin, None)
+
+    def known_vins(self) -> list[str]:
+        """Return the list of VINs currently in the cache."""
+        return list(self._data.keys())

--- a/custom_components/toyota/trips_cache.py
+++ b/custom_components/toyota/trips_cache.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING
 from homeassistant.helpers.storage import Store
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from homeassistant.core import HomeAssistant
 
 CACHE_VERSION = 1
@@ -106,3 +108,11 @@ class TripsCacheStore:
     def known_vins(self) -> list[str]:
         """Return the list of VINs currently in the cache."""
         return list(self._data.keys())
+
+    def prune_to(self, vins: Iterable[str]) -> bool:
+        """Drop cached entries for VINs not in ``vins``. Returns True if mutated."""
+        keep = set(vins)
+        stale = [v for v in self._data if v not in keep]
+        for v in stale:
+            self._data.pop(v, None)
+        return bool(stale)

--- a/custom_components/toyota/trips_manager.py
+++ b/custom_components/toyota/trips_manager.py
@@ -1,0 +1,296 @@
+"""Recent-trips manager: glues TripsCacheStore + transform + fetch logic.
+
+One manager per config entry. Lifecycle:
+
+- Setup: ``async setup()`` loads the on-disk cache. Entry-scoped state lives
+  in ``hass.data[DOMAIN][f"{entry_id}_trips_state"]`` and tracks per-VIN
+  followup-pending flags.
+- Per-VIN per-cycle: coordinator calls ``async_maybe_refresh(vehicle, vin,
+  decision)`` after ``_enact_decision`` returns. Manager decides whether to
+  fetch based on the decision's trigger (just_stopped / followup) and the
+  cache state (cold start vs steady state).
+- Service / button: ``async_service_refresh(vin, vehicle, limit)`` discards
+  the cache for that VIN and refetches ``limit`` trips, populating the
+  cache. Works regardless of ``max_recent_trips`` config.
+
+Pure orchestration; the actual transform lives in trips_transform.py and the
+storage in trips_cache.py.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from .refresh_strategy import RefreshTrigger
+from .trips_cache import TripsCacheStore
+from .trips_transform import to_card_shape
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from pytoyoda.models.vehicle import Vehicle
+
+    from .refresh_strategy import RefreshDecision
+
+_LOGGER = logging.getLogger(__name__)
+
+# How many trips to fetch on the steady-state delta-check path. Two is the
+# minimum that lets us distinguish "one new trip since last cycle" from "gap
+# of two or more new trips since last cycle"; the latter triggers a full
+# refill via ``max_recent_trips``.
+DELTA_FETCH_LIMIT = 2
+
+
+class RecentTripsManager:
+    """Per-config-entry orchestrator for the recent-trips sensor data path.
+
+    Independent of the existing cycle's ``trip_history`` endpoint (which
+    stays at limit=1, route=False for backward compatibility). This manager
+    issues separate ``Vehicle.get_recent_trips()`` calls when configured.
+    """
+
+    def __init__(
+        self, hass: HomeAssistant, entry: ConfigEntry, max_recent_trips: int
+    ) -> None:
+        """Bind the manager to a config entry and current options."""
+        self._hass = hass
+        self._entry_id = entry.entry_id
+        self._max = max_recent_trips
+        self._cache = TripsCacheStore(hass, entry.entry_id)
+        # In-memory state: per-VIN dict tracking whether a JUST_STOPPED tick
+        # produced no new trip (so we should also fetch on JUST_STOPPED_FOLLOWUP).
+        # Lost on restart; that's fine since on restart we have no signal to
+        # need a followup retry until the next stop event anyway.
+        self._followup_pending: dict[str, bool] = {}
+        # Per-VIN flag: cache was loaded under-filled (fewer trips than current
+        # max, after trim). Set in async_setup, cleared in async_maybe_refresh
+        # after a one-shot refill. Covers the user-raised-max case (e.g. 5 -> 10
+        # via options flow) where the cache survives the reload but at the old
+        # smaller size; we want the next refresh tick to top it back up.
+        self._underfilled_vins: set[str] = set()
+
+    async def async_setup(self) -> None:
+        """Load the on-disk cache, trim VINs over max, mark under-filled VINs.
+
+        Trim covers the case where ``max_recent_trips`` was lowered via the
+        options flow (5 -> 3): cache shrinks. Marking under-filled VINs
+        covers the inverse - max raised (5 -> 10): the trim is a no-op but
+        we want to seed back up to the new ceiling on the next refresh tick.
+        Idempotent; safe to call repeatedly.
+        """
+        await self._cache.load()
+        mutated = False
+        for vin in list(self._cache.known_vins()):
+            before = len(self._cache.get(vin))
+            self._cache.trim(vin, self._max)
+            after = len(self._cache.get(vin))
+            if after != before:
+                mutated = True
+            if 0 < after < self._max:
+                self._underfilled_vins.add(vin)
+        if mutated:
+            await self._cache.save()
+
+    @property
+    def cache(self) -> TripsCacheStore:
+        """Direct access to the cache store. Read-only contract for sensors."""
+        return self._cache
+
+    @property
+    def max_recent_trips(self) -> int:
+        """Current configured cap. 0 means auto-fetch is disabled."""
+        return self._max
+
+    def update_max(self, new_max: int) -> bool:
+        """React to options-flow change in ``max_recent_trips``.
+
+        Lowered (10 -> 5): trim cache to new size, no refetch.
+        Raised  (5 -> 10): leave cache alone; coordinator's next maybe_refresh
+            will see ``len(cache) < new_max`` and seed the gap.
+        Set to 0: drop entries entirely; sensor reports 0 trips, auto-fetch off.
+
+        Returns True if the cache was mutated (caller should persist).
+        """
+        if new_max == self._max:
+            return False
+        old_max = self._max
+        self._max = new_max
+        if new_max < old_max:
+            for vin in self._cache.known_vins():
+                self._cache.trim(vin, new_max)
+            return True
+        # Raised: nothing to do here; the next refresh tick will fill via
+        # the cache-cold-start branch in async_maybe_refresh.
+        return False
+
+    async def async_maybe_refresh(
+        self,
+        vehicle: Vehicle,
+        vin: str,
+        decision: RefreshDecision,
+    ) -> None:
+        """Fetch trips per the rolling-cache + delta lifecycle.
+
+        Called once per VIN per coordinator cycle. No-op when disabled.
+        """
+        if self._max <= 0:
+            return
+
+        # Cold start (cache empty for this VIN): seed with limit=max trips.
+        # This covers fresh integration install, fresh-enable post-options-flow,
+        # and post-clear-cache scenarios. Independent of trigger.
+        if not self._cache.get(vin):
+            await self._seed_cache(vehicle, vin, self._max)
+            return
+
+        # Under-filled cache (cache was already on disk with fewer trips than
+        # the current max, typically because the user just raised max via
+        # options-flow). Seed once with limit=max to refill, then drop the
+        # underfill flag so subsequent ticks fall through to normal delta-fetch.
+        if vin in self._underfilled_vins:
+            await self._seed_cache(vehicle, vin, self._max)
+            self._underfilled_vins.discard(vin)
+            return
+
+        # Steady state: fetch only on stop-event triggers.
+        # JUST_STOPPED: primary trigger.
+        # JUST_STOPPED_FOLLOWUP: only if the prior just_stopped fetch yielded
+        # no new trip (Toyota hadn't processed it yet).
+        trigger = decision.trigger
+
+        if trigger is RefreshTrigger.JUST_STOPPED:
+            yielded_new = await self._delta_fetch(vehicle, vin)
+            self._followup_pending[vin] = not yielded_new
+        elif (
+            trigger is RefreshTrigger.JUST_STOPPED_FOLLOWUP
+            and self._followup_pending.get(vin)
+        ):
+            yielded_new = await self._delta_fetch(vehicle, vin)
+            self._followup_pending[vin] = (
+                False if yielded_new else self._followup_pending.get(vin, False)
+            )
+        # All other triggers: no-op. Trips don't change between drives.
+
+    async def async_service_refresh(
+        self, vin: str, vehicle: Vehicle, limit: int
+    ) -> int:
+        """Discard cache for VIN, fetch ``limit`` trips, populate cache.
+
+        Used by the ``toyota.refresh_recent_trips`` service and the per-vehicle
+        ``Refresh recent trips`` button. Works regardless of ``max_recent_trips``
+        config (so users with auto-fetch off can still drive fetches via
+        automations).
+
+        Returns the count of trips placed in cache.
+        """
+        if not 1 <= limit <= 50:  # noqa: PLR2004
+            msg = f"limit must be between 1 and 50, got {limit}"
+            raise ValueError(msg)
+        self._cache.clear(vin)
+        await self._seed_cache(vehicle, vin, limit)
+        return len(self._cache.get(vin))
+
+    async def _seed_cache(self, vehicle: Vehicle, vin: str, limit: int) -> None:
+        """Fetch ``limit`` trips with route, transform, populate cache."""
+        try:
+            trips = await vehicle.get_recent_trips(limit=limit, with_route=True)
+        except Exception:
+            _LOGGER.exception(
+                "Toyota recent-trips seed-fetch failed for vin=...%s", vin[-6:]
+            )
+            return
+        card_trips: list[dict] = []
+        alias = vehicle.alias if hasattr(vehicle, "alias") else None
+        for t in trips:
+            raw = self._raw_trip_dict(t)
+            if raw is None:
+                continue
+            shape = to_card_shape(raw, alias)
+            if shape is not None:
+                card_trips.append(shape)
+        self._cache.set(vin, card_trips)
+        await self._cache.save()
+        _LOGGER.debug(
+            "Toyota recent-trips seeded vin=...%s with %d trips (limit=%d)",
+            vin[-6:],
+            len(card_trips),
+            limit,
+        )
+
+    async def _delta_fetch(self, vehicle: Vehicle, vin: str) -> bool:
+        """Fetch the most recent N trips (DELTA_FETCH_LIMIT), dedup, append.
+
+        Returns True if at least one new trip was added to the cache, False
+        otherwise (caller uses this to decide whether followup retry needed).
+        """
+        try:
+            trips = await vehicle.get_recent_trips(
+                limit=DELTA_FETCH_LIMIT, with_route=True
+            )
+        except Exception:
+            _LOGGER.exception(
+                "Toyota recent-trips delta-fetch failed for vin=...%s", vin[-6:]
+            )
+            return False
+        if not trips:
+            return False
+
+        alias = vehicle.alias if hasattr(vehicle, "alias") else None
+        # Walk newest-first; collect shapes that are actually new.
+        new_shapes: list[dict] = []
+        seen_existing = False
+        for t in trips:
+            raw = self._raw_trip_dict(t)
+            if raw is None:
+                continue
+            trip_id = raw.get("id")
+            if trip_id and self._cache.has_trip_id(vin, trip_id):
+                seen_existing = True
+                break
+            shape = to_card_shape(raw, alias)
+            if shape is not None:
+                new_shapes.append(shape)
+
+        if not new_shapes:
+            # All returned trips are already cached; nothing new.
+            return False
+
+        if not seen_existing and len(new_shapes) >= DELTA_FETCH_LIMIT:
+            # Both fetched trips are new and we didn't see any cached one in
+            # the overlap. Gap detected (HA was down or we missed cycles);
+            # fall back to a full reseed to catch up.
+            _LOGGER.info(
+                "Toyota recent-trips gap detected for vin=...%s, refilling", vin[-6:]
+            )
+            await self._seed_cache(vehicle, vin, self._max)
+            return True
+
+        # Normal case: prepend the new ones (they came back newest-first).
+        for shape in reversed(new_shapes):
+            # Reversed so the newest ends up at index 0 after sequential prepends.
+            self._cache.append(vin, shape, self._max)
+        await self._cache.save()
+        _LOGGER.debug(
+            "Toyota recent-trips delta vin=...%s appended %d new trip(s)",
+            vin[-6:],
+            len(new_shapes),
+        )
+        return True
+
+    @staticmethod
+    def _raw_trip_dict(trip_obj) -> dict | None:  # type: ignore[no-untyped-def]  # noqa: ANN001
+        """Extract the raw _TripModel dict from a pytoyoda Trip wrapper.
+
+        pytoyoda's Trip wrapper holds the underlying _TripModel at ``_trip``.
+        We use ``.model_dump(by_alias=True)`` to get the JSON-shape with
+        Toyota's native camelCase keys (matching what ``to_card_shape``
+        expects). Returns None on any access failure.
+        """
+        try:
+            inner = getattr(trip_obj, "_trip", None)
+            if inner is None or not hasattr(inner, "model_dump"):
+                return None
+        except Exception:  # noqa: BLE001
+            return None
+        return inner.model_dump(by_alias=True, mode="python")

--- a/custom_components/toyota/trips_manager.py
+++ b/custom_components/toyota/trips_manager.py
@@ -193,10 +193,12 @@ class RecentTripsManager:
                 await self._seed_cache(vehicle, vin, self._max)
                 return
 
-            # Under-filled cache (raise-max via options flow). One-shot refill.
+            # Under-filled cache (raise-max via options flow). One-shot
+            # refill; keep the flag armed if the fetch failed so a later
+            # cycle retries instead of leaving the cache short forever.
             if vin in self._underfilled_vins:
-                await self._seed_cache(vehicle, vin, self._max)
-                self._underfilled_vins.discard(vin)
+                if await self._seed_cache(vehicle, vin, self._max):
+                    self._underfilled_vins.discard(vin)
                 return
 
             # Cache top matches Toyota's latest trip - nothing new since
@@ -279,14 +281,16 @@ class RecentTripsManager:
                 out.append(shape)
         return out
 
-    async def _seed_cache(self, vehicle: Vehicle, vin: str, limit: int) -> None:
-        """Fetch + commit (set + save). On fetch failure, cache untouched.
+    async def _seed_cache(self, vehicle: Vehicle, vin: str, limit: int) -> bool:
+        """Fetch + commit (set + save); True on success.
 
+        On fetch failure the cache is untouched and False is returned so
+        callers can keep retry state (e.g. the underfilled one-shot) armed.
         Caller must hold ``self._lock(vin)``.
         """
         shapes = await self._fetch_shapes(vehicle, vin, limit)
         if shapes is None:
-            return
+            return False
         self._cache.set(vin, shapes)
         await self._cache.save()
         _LOGGER.debug(
@@ -295,6 +299,7 @@ class RecentTripsManager:
             len(shapes),
             limit,
         )
+        return True
 
     async def _delta_fetch(self, vehicle: Vehicle, vin: str) -> bool:
         """Fetch DELTA_FETCH_LIMIT trips, dedup, append. Caller holds the lock.

--- a/custom_components/toyota/trips_manager.py
+++ b/custom_components/toyota/trips_manager.py
@@ -138,14 +138,47 @@ class RecentTripsManager:
     ) -> None:
         """Fetch trips per the rolling-cache + delta lifecycle.
 
-        Called once per VIN per coordinator cycle. No-op when disabled.
+        Called once per VIN per coordinator cycle. No-op when disabled
+        (``max_recent_trips <= 0``). Uses ``vehicle.trip_history`` -
+        already populated by the cycle's `/v1/trips?summary=True&limit=1
+        &route=False` call - as a free piggyback signal:
+
+        - ``trip_history is None``: endpoint failed this cycle (now
+          optional in pytoyoda). Conservative: skip auto-fetch; the
+          service-refresh button still works.
+        - ``trip_history == []``: vehicle has no trips data at all (e.g.
+          AYGO X on Toyota Connect Lite tier). Skip entirely - no
+          redundant ``with_route`` fetch.
+        - ``trip_history[0].id == cache[0].id``: cache is in sync with
+          Toyota's view. Skip the heavier ``with_route`` fetch; on
+          ``JUST_STOPPED`` mark followup-pending in case Toyota's
+          summary endpoint is also lagging behind a freshly-driven
+          trip.
+        - mismatch: there's a new trip we don't have. Cold-start when
+          cache empty; delta-fetch on stop triggers; otherwise no-op.
         """
         if self._max <= 0:
             return
 
+        # Read piggyback signal. Use getattr defensively - tests use
+        # bare SimpleNamespace stubs that may not declare the attribute.
+        history = getattr(vehicle, "trip_history", None)
+        if history is None:
+            return
+        if not history:
+            return
+        latest_id = self._extract_trip_id(history[0])
+        if latest_id is None:
+            return  # Defensive; production trips always have UUIDs.
+
         async with self._lock(vin):
+            cache = self._cache.get(vin)
+            cache_top_id = (
+                str(cache[0].get("id")) if cache and cache[0].get("id") else None
+            )
+
             # Cold start: seed with limit=max trips.
-            if not self._cache.get(vin):
+            if not cache:
                 await self._seed_cache(vehicle, vin, self._max)
                 return
 
@@ -155,7 +188,17 @@ class RecentTripsManager:
                 self._underfilled_vins.discard(vin)
                 return
 
-            # Steady state: fetch only on stop-event triggers.
+            # Cache top matches Toyota's latest trip - nothing new since
+            # last cycle. Skip the heavier with_route fetch; on JUST_STOPPED
+            # mark followup-pending so a delayed-ingest trip gets caught
+            # next cycle.
+            if cache_top_id == latest_id:
+                if decision.trigger is RefreshTrigger.JUST_STOPPED:
+                    self._followup_pending[vin] = True
+                return
+
+            # Mismatch: there's a new trip we don't have. Delta-fetch on
+            # stop-event triggers.
             trigger = decision.trigger
             if trigger is RefreshTrigger.JUST_STOPPED:
                 yielded_new = await self._delta_fetch(vehicle, vin)
@@ -168,6 +211,20 @@ class RecentTripsManager:
                 self._followup_pending[vin] = (
                     False if yielded_new else self._followup_pending.get(vin, False)
                 )
+
+    @staticmethod
+    def _extract_trip_id(trip_obj) -> str | None:  # type: ignore[no-untyped-def]  # noqa: ANN001
+        """Pull a stringified trip id off a pytoyoda Trip wrapper.
+
+        ``Trip._trip.id`` is a UUID; cached trip dicts store the same
+        value as ``str``. Stringify both ends before comparison so
+        UUID/str equality lines up.
+        """
+        inner = getattr(trip_obj, "_trip", None)
+        if inner is None:
+            return None
+        tid = getattr(inner, "id", None)
+        return str(tid) if tid is not None else None
 
     async def async_service_refresh(
         self, vin: str, vehicle: Vehicle, limit: int

--- a/custom_components/toyota/trips_manager.py
+++ b/custom_components/toyota/trips_manager.py
@@ -19,6 +19,7 @@ storage in trips_cache.py.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 
@@ -27,6 +28,8 @@ from .trips_cache import TripsCacheStore
 from .trips_transform import to_card_shape
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from pytoyoda.models.vehicle import Vehicle
@@ -69,6 +72,11 @@ class RecentTripsManager:
         # via options flow) where the cache survives the reload but at the old
         # smaller size; we want the next refresh tick to top it back up.
         self._underfilled_vins: set[str] = set()
+        # Per-VIN locks serialise cache mutation paths (cold-start seed,
+        # delta-fetch, service refresh). Without them a coordinator stop tick
+        # racing a service/button call can issue duplicate get_recent_trips
+        # calls and last-writer-wins on the cache + _followup_pending state.
+        self._locks: dict[str, asyncio.Lock] = {}
 
     async def async_setup(self) -> None:
         """Load the on-disk cache, trim VINs over max, mark under-filled VINs.
@@ -102,27 +110,25 @@ class RecentTripsManager:
         """Current configured cap. 0 means auto-fetch is disabled."""
         return self._max
 
-    def update_max(self, new_max: int) -> bool:
-        """React to options-flow change in ``max_recent_trips``.
+    def _lock(self, vin: str) -> asyncio.Lock:
+        """Per-VIN lock; created on first use."""
+        lock = self._locks.get(vin)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[vin] = lock
+        return lock
 
-        Lowered (10 -> 5): trim cache to new size, no refetch.
-        Raised  (5 -> 10): leave cache alone; coordinator's next maybe_refresh
-            will see ``len(cache) < new_max`` and seed the gap.
-        Set to 0: drop entries entirely; sensor reports 0 trips, auto-fetch off.
+    async def async_prune_orphans(self, known_vins: Iterable[str]) -> bool:
+        """Drop cached VINs not in ``known_vins`` and persist if mutated.
 
-        Returns True if the cache was mutated (caller should persist).
+        Called by the coordinator after the first successful refresh, so
+        VINs the user removed from their Toyota account stop accumulating
+        in the on-disk cache.
         """
-        if new_max == self._max:
-            return False
-        old_max = self._max
-        self._max = new_max
-        if new_max < old_max:
-            for vin in self._cache.known_vins():
-                self._cache.trim(vin, new_max)
-            return True
-        # Raised: nothing to do here; the next refresh tick will fill via
-        # the cache-cold-start branch in async_maybe_refresh.
-        return False
+        mutated = self._cache.prune_to(known_vins)
+        if mutated:
+            await self._cache.save()
+        return mutated
 
     async def async_maybe_refresh(
         self,
@@ -137,138 +143,124 @@ class RecentTripsManager:
         if self._max <= 0:
             return
 
-        # Cold start (cache empty for this VIN): seed with limit=max trips.
-        # This covers fresh integration install, fresh-enable post-options-flow,
-        # and post-clear-cache scenarios. Independent of trigger.
-        if not self._cache.get(vin):
-            await self._seed_cache(vehicle, vin, self._max)
-            return
+        async with self._lock(vin):
+            # Cold start: seed with limit=max trips.
+            if not self._cache.get(vin):
+                await self._seed_cache(vehicle, vin, self._max)
+                return
 
-        # Under-filled cache (cache was already on disk with fewer trips than
-        # the current max, typically because the user just raised max via
-        # options-flow). Seed once with limit=max to refill, then drop the
-        # underfill flag so subsequent ticks fall through to normal delta-fetch.
-        if vin in self._underfilled_vins:
-            await self._seed_cache(vehicle, vin, self._max)
-            self._underfilled_vins.discard(vin)
-            return
+            # Under-filled cache (raise-max via options flow). One-shot refill.
+            if vin in self._underfilled_vins:
+                await self._seed_cache(vehicle, vin, self._max)
+                self._underfilled_vins.discard(vin)
+                return
 
-        # Steady state: fetch only on stop-event triggers.
-        # JUST_STOPPED: primary trigger.
-        # JUST_STOPPED_FOLLOWUP: only if the prior just_stopped fetch yielded
-        # no new trip (Toyota hadn't processed it yet).
-        trigger = decision.trigger
-
-        if trigger is RefreshTrigger.JUST_STOPPED:
-            yielded_new = await self._delta_fetch(vehicle, vin)
-            self._followup_pending[vin] = not yielded_new
-        elif (
-            trigger is RefreshTrigger.JUST_STOPPED_FOLLOWUP
-            and self._followup_pending.get(vin)
-        ):
-            yielded_new = await self._delta_fetch(vehicle, vin)
-            self._followup_pending[vin] = (
-                False if yielded_new else self._followup_pending.get(vin, False)
-            )
-        # All other triggers: no-op. Trips don't change between drives.
+            # Steady state: fetch only on stop-event triggers.
+            trigger = decision.trigger
+            if trigger is RefreshTrigger.JUST_STOPPED:
+                yielded_new = await self._delta_fetch(vehicle, vin)
+                self._followup_pending[vin] = not yielded_new
+            elif (
+                trigger is RefreshTrigger.JUST_STOPPED_FOLLOWUP
+                and self._followup_pending.get(vin)
+            ):
+                yielded_new = await self._delta_fetch(vehicle, vin)
+                self._followup_pending[vin] = (
+                    False if yielded_new else self._followup_pending.get(vin, False)
+                )
 
     async def async_service_refresh(
         self, vin: str, vehicle: Vehicle, limit: int
     ) -> int:
-        """Discard cache for VIN, fetch ``limit`` trips, populate cache.
+        """Replace cache for VIN with ``limit`` freshly fetched trips.
 
-        Used by the ``toyota.refresh_recent_trips`` service and the per-vehicle
-        ``Refresh recent trips`` button. Works regardless of ``max_recent_trips``
-        config (so users with auto-fetch off can still drive fetches via
-        automations).
-
-        Returns the count of trips placed in cache.
+        On fetch failure, prior cache contents are preserved (fail-safe).
+        Works regardless of ``max_recent_trips`` config.
         """
         if not 1 <= limit <= 50:  # noqa: PLR2004
             msg = f"limit must be between 1 and 50, got {limit}"
             raise ValueError(msg)
-        self._cache.clear(vin)
-        await self._seed_cache(vehicle, vin, limit)
-        return len(self._cache.get(vin))
+        async with self._lock(vin):
+            shapes = await self._fetch_shapes(vehicle, vin, limit)
+            if shapes is None:
+                # Fetch failed; keep prior cache rather than nuking it.
+                return len(self._cache.get(vin))
+            self._cache.set(vin, shapes)
+            await self._cache.save()
+            return len(shapes)
 
-    async def _seed_cache(self, vehicle: Vehicle, vin: str, limit: int) -> None:
-        """Fetch ``limit`` trips with route, transform, populate cache."""
+    async def _fetch_shapes(
+        self, vehicle: Vehicle, vin: str, limit: int
+    ) -> list[dict] | None:
+        """Fetch + transform. Returns None on fetch failure, list on success."""
         try:
             trips = await vehicle.get_recent_trips(limit=limit, with_route=True)
         except Exception:
             _LOGGER.exception(
-                "Toyota recent-trips seed-fetch failed for vin=...%s", vin[-6:]
+                "Toyota recent-trips fetch failed for vin=...%s", vin[-6:]
             )
-            return
-        card_trips: list[dict] = []
+            return None
         alias = vehicle.alias if hasattr(vehicle, "alias") else None
+        out: list[dict] = []
         for t in trips:
             raw = self._raw_trip_dict(t)
             if raw is None:
                 continue
             shape = to_card_shape(raw, alias)
             if shape is not None:
-                card_trips.append(shape)
-        self._cache.set(vin, card_trips)
+                out.append(shape)
+        return out
+
+    async def _seed_cache(self, vehicle: Vehicle, vin: str, limit: int) -> None:
+        """Fetch + commit (set + save). On fetch failure, cache untouched.
+
+        Caller must hold ``self._lock(vin)``.
+        """
+        shapes = await self._fetch_shapes(vehicle, vin, limit)
+        if shapes is None:
+            return
+        self._cache.set(vin, shapes)
         await self._cache.save()
         _LOGGER.debug(
             "Toyota recent-trips seeded vin=...%s with %d trips (limit=%d)",
             vin[-6:],
-            len(card_trips),
+            len(shapes),
             limit,
         )
 
     async def _delta_fetch(self, vehicle: Vehicle, vin: str) -> bool:
-        """Fetch the most recent N trips (DELTA_FETCH_LIMIT), dedup, append.
+        """Fetch DELTA_FETCH_LIMIT trips, dedup, append. Caller holds the lock.
 
-        Returns True if at least one new trip was added to the cache, False
-        otherwise (caller uses this to decide whether followup retry needed).
+        Returns True if at least one new trip was added to the cache.
         """
-        try:
-            trips = await vehicle.get_recent_trips(
-                limit=DELTA_FETCH_LIMIT, with_route=True
-            )
-        except Exception:
-            _LOGGER.exception(
-                "Toyota recent-trips delta-fetch failed for vin=...%s", vin[-6:]
-            )
-            return False
-        if not trips:
+        shapes = await self._fetch_shapes(vehicle, vin, DELTA_FETCH_LIMIT)
+        if shapes is None or not shapes:
             return False
 
-        alias = vehicle.alias if hasattr(vehicle, "alias") else None
         # Walk newest-first; collect shapes that are actually new.
         new_shapes: list[dict] = []
         seen_existing = False
-        for t in trips:
-            raw = self._raw_trip_dict(t)
-            if raw is None:
-                continue
-            trip_id = raw.get("id")
+        for shape in shapes:
+            trip_id = shape.get("id")
             if trip_id and self._cache.has_trip_id(vin, trip_id):
                 seen_existing = True
                 break
-            shape = to_card_shape(raw, alias)
-            if shape is not None:
-                new_shapes.append(shape)
+            new_shapes.append(shape)
 
         if not new_shapes:
-            # All returned trips are already cached; nothing new.
             return False
 
         if not seen_existing and len(new_shapes) >= DELTA_FETCH_LIMIT:
-            # Both fetched trips are new and we didn't see any cached one in
-            # the overlap. Gap detected (HA was down or we missed cycles);
-            # fall back to a full reseed to catch up.
+            # Both fetched trips are new with no overlap: gap (HA down or
+            # missed cycles); reseed to catch up.
             _LOGGER.info(
                 "Toyota recent-trips gap detected for vin=...%s, refilling", vin[-6:]
             )
             await self._seed_cache(vehicle, vin, self._max)
             return True
 
-        # Normal case: prepend the new ones (they came back newest-first).
+        # Newest-first; reverse so that sequential prepends end with newest at 0.
         for shape in reversed(new_shapes):
-            # Reversed so the newest ends up at index 0 after sequential prepends.
             self._cache.append(vin, shape, self._max)
         await self._cache.save()
         _LOGGER.debug(
@@ -282,10 +274,9 @@ class RecentTripsManager:
     def _raw_trip_dict(trip_obj) -> dict | None:  # type: ignore[no-untyped-def]  # noqa: ANN001
         """Extract the raw _TripModel dict from a pytoyoda Trip wrapper.
 
-        pytoyoda's Trip wrapper holds the underlying _TripModel at ``_trip``.
-        We use ``.model_dump(by_alias=True)`` to get the JSON-shape with
-        Toyota's native camelCase keys (matching what ``to_card_shape``
-        expects). Returns None on any access failure.
+        Couples to pytoyoda's private ``_trip`` attribute (manifest pin
+        pytoyoda>=5.1.0 guarantees it exists). If pytoyoda exposes a public
+        accessor in a future release, switch to it and bump the manifest pin.
         """
         try:
             inner = getattr(trip_obj, "_trip", None)

--- a/custom_components/toyota/trips_manager.py
+++ b/custom_components/toyota/trips_manager.py
@@ -130,25 +130,44 @@ class RecentTripsManager:
             await self._cache.save()
         return mutated
 
+    def _piggyback_latest_id(self, vehicle: Vehicle) -> str | None:
+        """Latest trip id from the cycle's free ``trip_history`` signal.
+
+        ``trip_history`` is already populated by the cycle's
+        `/v1/trips?summary=True&limit=1&route=False` call, so reading it
+        costs nothing. Returns None when auto-fetch should be skipped:
+
+        - feature disabled (``max_recent_trips <= 0``);
+        - ``trip_history is None``: endpoint failed this cycle (now
+          optional in pytoyoda) - conservative skip, the service-refresh
+          button still works;
+        - ``trip_history == []``: vehicle has no trips data at all (e.g.
+          AYGO X on Toyota Connect Lite tier) - no redundant
+          ``with_route`` fetch;
+        - no id on the record (defensive; production trips have UUIDs).
+
+        Reads via getattr - tests use bare SimpleNamespace stubs that may
+        not declare the attribute.
+        """
+        if self._max <= 0:
+            return None
+        history = getattr(vehicle, "trip_history", None)
+        if not history:
+            return None
+        return self._extract_trip_id(history[0])
+
     async def async_maybe_refresh(
         self,
         vehicle: Vehicle,
-        vin: str,
+        vin: str | None,
         decision: RefreshDecision,
     ) -> None:
         """Fetch trips per the rolling-cache + delta lifecycle.
 
-        Called once per VIN per coordinator cycle. No-op when disabled
-        (``max_recent_trips <= 0``). Uses ``vehicle.trip_history`` -
-        already populated by the cycle's `/v1/trips?summary=True&limit=1
-        &route=False` call - as a free piggyback signal:
+        Called once per VIN per coordinator cycle (vin may be None for a
+        vehicle without one; no-op). Gating on the free piggyback signal
+        is documented on :meth:`_piggyback_latest_id`. Cache semantics:
 
-        - ``trip_history is None``: endpoint failed this cycle (now
-          optional in pytoyoda). Conservative: skip auto-fetch; the
-          service-refresh button still works.
-        - ``trip_history == []``: vehicle has no trips data at all (e.g.
-          AYGO X on Toyota Connect Lite tier). Skip entirely - no
-          redundant ``with_route`` fetch.
         - ``trip_history[0].id == cache[0].id``: cache is in sync with
           Toyota's view. Skip the heavier ``with_route`` fetch; on
           ``JUST_STOPPED`` mark followup-pending in case Toyota's
@@ -157,19 +176,11 @@ class RecentTripsManager:
         - mismatch: there's a new trip we don't have. Cold-start when
           cache empty; delta-fetch on stop triggers; otherwise no-op.
         """
-        if self._max <= 0:
+        if not vin:
             return
-
-        # Read piggyback signal. Use getattr defensively - tests use
-        # bare SimpleNamespace stubs that may not declare the attribute.
-        history = getattr(vehicle, "trip_history", None)
-        if history is None:
-            return
-        if not history:
-            return
-        latest_id = self._extract_trip_id(history[0])
+        latest_id = self._piggyback_latest_id(vehicle)
         if latest_id is None:
-            return  # Defensive; production trips always have UUIDs.
+            return
 
         async with self._lock(vin):
             cache = self._cache.get(vin)

--- a/custom_components/toyota/trips_transform.py
+++ b/custom_components/toyota/trips_transform.py
@@ -1,0 +1,138 @@
+"""Transform pytoyoda's _TripModel dicts to the journey-viewer-card Trip shape.
+
+pytoyoda exposes trips through Pydantic-aliased camelCase keys (Toyota's
+native shape: ``startTs``, ``startLat``, ``averageSpeed`` etc.). The
+journey-viewer-card data contract is source-agnostic snake_case
+(``start_ts``, ``stats.average_speed_kmh`` etc.). This module bridges the
+two for Toyota source.
+
+Lifted with minor adjustments from
+``endpoint-exploration/fetch-trips.py:_to_card_shape``. Differences:
+
+- Drops absent optional fields (None-valued) entirely, per the multi-source
+  design (each source's normaliser only writes fields its source has).
+- Returns immediately on missing summary - the trip can't be rendered
+  meaningfully without start/end.
+
+Pure function, no I/O. Tested in tests/test_trips_transform.py.
+"""
+
+from __future__ import annotations
+
+_ROUTE_OPTIONAL_KEYS = ("overspeed", "highway", "mode", "isEv")
+
+_STATS_KEYS_FROM_SUMMARY: dict[str, str] = {
+    # card_key -> Toyota summary key
+    "distance_m": "length",
+    "duration_s": "duration",
+    "duration_idle_s": "durationIdle",
+    "max_speed_kmh": "maxSpeed",
+    "average_speed_kmh": "averageSpeed",
+    "fuel_consumption_ml": "fuelConsumption",
+    "length_overspeed_m": "lengthOverspeed",
+    "duration_overspeed_s": "durationOverspeed",
+    "length_highway_m": "lengthHighway",
+    "duration_highway_s": "durationHighway",
+    "countries": "countries",
+    "night_trip": "nightTrip",
+}
+
+_STATS_KEYS_FROM_HDC: dict[str, str] = {
+    # card_key -> Toyota hdc key (PHEV-only; absent on AYGO)
+    "ev_time_s": "evTime",
+    "ev_distance_m": "evDistance",
+    "charge_time_s": "chargeTime",
+    "charge_distance_m": "chargeDist",
+    "eco_time_s": "ecoTime",
+    "eco_distance_m": "ecoDist",
+    "power_time_s": "powerTime",
+    "power_distance_m": "powerDist",
+}
+
+
+def _coerce_route(route_in: list[dict]) -> list[dict]:
+    """Map Toyota route points to card RoutePoints, dropping the ones missing GPS.
+
+    Per route point we keep ``lat``/``lon`` always, plus any of
+    ``overspeed``/``highway``/``mode``/``isEv`` that's present (None values
+    are dropped). The card consumer treats absent flags the same as None.
+    """
+    out: list[dict] = []
+    for pt in route_in or []:
+        lat = pt.get("lat")
+        lon = pt.get("lon")
+        if lat is None or lon is None:
+            continue
+        item: dict = {"lat": lat, "lon": lon}
+        for opt in _ROUTE_OPTIONAL_KEYS:
+            v = pt.get(opt)
+            if v is not None:
+                item[opt] = v
+        out.append(item)
+    return out
+
+
+def _build_stats(summary: dict, hdc: dict | None) -> dict:
+    """Build the stats dict, omitting keys whose source value is None.
+
+    Per Q3 of the recent-trips design interview: drop absent fields rather
+    than write None. Multi-source rationale - each source's normaliser only
+    writes fields its source has.
+    """
+    stats: dict = {}
+    for card_key, src_key in _STATS_KEYS_FROM_SUMMARY.items():
+        v = summary.get(src_key)
+        if v is not None:
+            stats[card_key] = v
+    if hdc:
+        for card_key, src_key in _STATS_KEYS_FROM_HDC.items():
+            v = hdc.get(src_key)
+            if v is not None:
+                stats[card_key] = v
+    return stats
+
+
+def to_card_shape(trip_dict: dict, vehicle_alias: str | None) -> dict | None:
+    """Map a pytoyoda _TripModel dict to the journey-viewer-card Trip shape.
+
+    Returns None if the trip has no summary - we can't render a trip with
+    no start/end timestamps or coordinates.
+
+    Args:
+        trip_dict: Result of ``_TripModel.model_dump(by_alias=True)`` or the
+            equivalent raw API response trip object.
+        vehicle_alias: For the ``source`` field on the resulting Trip.
+            Defaults to ``"toyota"`` when None.
+
+    Returns:
+        A dict matching the ``Trip`` interface in
+        ``journey-viewer-card/src/types.ts``, or None if untransformable.
+    """
+    summary = trip_dict.get("summary") or {}
+    if not summary:
+        return None
+
+    hdc = trip_dict.get("hdc")
+    scores = trip_dict.get("scores")
+    behaviours = trip_dict.get("behaviours")
+    route_in = trip_dict.get("route") or []
+
+    out: dict = {
+        "id": trip_dict.get("id"),
+        "source": (vehicle_alias or "toyota").lower(),
+        "activity_type": "drive",
+        "start_ts": summary.get("startTs"),
+        "end_ts": summary.get("endTs"),
+        "start": {"lat": summary.get("startLat"), "lon": summary.get("startLon")},
+        "end": {"lat": summary.get("endLat"), "lon": summary.get("endLon")},
+        "route": _coerce_route(route_in),
+        "stats": _build_stats(summary, hdc if isinstance(hdc, dict) else None),
+    }
+
+    # Drop the trip-level optional fields when absent (Q3).
+    if scores:
+        out["scores"] = scores
+    if behaviours:
+        out["behaviours"] = behaviours
+
+    return out

--- a/tests/test_sensor_recent_trips_attrs.py
+++ b/tests/test_sensor_recent_trips_attrs.py
@@ -1,0 +1,76 @@
+"""Tests for the _strip_route helper that slims sensor attribute payloads."""
+
+from __future__ import annotations
+
+from custom_components.toyota.sensor import _strip_route
+
+
+def _trip_with_route(route_points: int) -> dict:
+    return {
+        "id": "abc-123",
+        "start_ts": "2026-05-07T14:01:57+00:00",
+        "end_ts": "2026-05-07T14:32:11+00:00",
+        "stats": {"distance_m": 5257, "duration_s": 1814},
+        "behaviours": [{"ts": "...", "type": "B"}],
+        "scores": {"global": 73},
+        "route": [
+            {"lat": 47.0 + i / 1000.0, "lon": 20.0 + i / 1000.0}
+            for i in range(route_points)
+        ],
+    }
+
+
+def test_strip_route_removes_route_key():
+    out = _strip_route(_trip_with_route(50))
+    assert "route" not in out
+
+
+def test_strip_route_replaces_with_count():
+    out = _strip_route(_trip_with_route(2584))
+    assert out["route_point_count"] == 2584
+
+
+def test_strip_route_preserves_other_fields():
+    src = _trip_with_route(10)
+    out = _strip_route(src)
+    for key in ("id", "start_ts", "end_ts", "stats", "behaviours", "scores"):
+        assert out[key] == src[key]
+
+
+def test_strip_route_handles_missing_route():
+    src = {"id": "no-route", "stats": {"distance_m": 100}}
+    out = _strip_route(src)
+    assert out["route_point_count"] == 0
+    assert out["id"] == "no-route"
+    assert out["stats"] == {"distance_m": 100}
+
+
+def test_strip_route_handles_none_route():
+    src = {"id": "none-route", "route": None}
+    out = _strip_route(src)
+    assert out["route_point_count"] == 0
+    assert "route" not in out
+
+
+def test_strip_route_does_not_mutate_input():
+    src = _trip_with_route(5)
+    src_before = {**src, "route": list(src["route"])}
+    _strip_route(src)
+    assert src == src_before
+
+
+def test_strip_route_payload_shrinks_dramatically():
+    """Sanity check: stripping the route brings the payload size down by 100x+.
+
+    Real-world example from the live RAV4 cache (2026-05-07): a single
+    111 km trip was 261,788 bytes JSON with route polyline, ~28 bytes
+    after stripping. This synthetic case mirrors the same shape with
+    minimal route fields, so absolute numbers are smaller; the ratio is
+    what we care about.
+    """
+    import json
+
+    full = _trip_with_route(2500)
+    full_size = len(json.dumps(full))
+    slim_size = len(json.dumps(_strip_route(full)))
+    assert full_size > slim_size * 100  # Order-of-magnitude shrinkage

--- a/tests/test_trips_cache.py
+++ b/tests/test_trips_cache.py
@@ -1,0 +1,191 @@
+"""Tests for the per-config-entry rolling trips cache (TripsCacheStore)."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.toyota.trips_cache import TripsCacheStore
+
+
+def _trip(trip_id: str, label: str = "") -> dict:
+    """Minimal card-shape trip dict for cache tests."""
+    return {"id": trip_id, "label": label or trip_id}
+
+
+@pytest.mark.asyncio
+async def test_load_uninitialised_returns_empty(hass):
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    assert cache.loaded is True
+    assert cache.get("VIN1") == []
+    assert cache.known_vins() == []
+
+
+@pytest.mark.asyncio
+async def test_set_and_get_round_trip(hass):
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.set("VIN1", [_trip("a"), _trip("b"), _trip("c")])
+    assert cache.get("VIN1") == [_trip("a"), _trip("b"), _trip("c")]
+    # get returns a copy; mutating it doesn't affect the cache
+    got = cache.get("VIN1")
+    got.append(_trip("z"))
+    assert cache.get("VIN1") == [_trip("a"), _trip("b"), _trip("c")]
+
+
+@pytest.mark.asyncio
+async def test_set_and_save_persists_across_instances(hass):
+    cache1 = TripsCacheStore(hass, "entry1")
+    await cache1.load()
+    cache1.set("VIN1", [_trip("a"), _trip("b")])
+    await cache1.save()
+
+    cache2 = TripsCacheStore(hass, "entry1")
+    await cache2.load()
+    assert cache2.get("VIN1") == [_trip("a"), _trip("b")]
+
+
+@pytest.mark.asyncio
+async def test_per_entry_isolation(hass):
+    """Two entries get separate stores, not shared state."""
+    cache_a = TripsCacheStore(hass, "entry_a")
+    cache_b = TripsCacheStore(hass, "entry_b")
+    await cache_a.load()
+    await cache_b.load()
+    cache_a.set("VIN1", [_trip("a-only")])
+    cache_b.set("VIN1", [_trip("b-only")])
+    await cache_a.save()
+    await cache_b.save()
+
+    cache_a2 = TripsCacheStore(hass, "entry_a")
+    cache_b2 = TripsCacheStore(hass, "entry_b")
+    await cache_a2.load()
+    await cache_b2.load()
+    assert cache_a2.get("VIN1") == [_trip("a-only")]
+    assert cache_b2.get("VIN1") == [_trip("b-only")]
+
+
+@pytest.mark.asyncio
+async def test_multi_vin_in_one_entry(hass):
+    """One config entry, two VINs, independent slots."""
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.set("VIN1", [_trip("v1-a")])
+    cache.set("VIN2", [_trip("v2-a"), _trip("v2-b")])
+    assert cache.get("VIN1") == [_trip("v1-a")]
+    assert cache.get("VIN2") == [_trip("v2-a"), _trip("v2-b")]
+    assert sorted(cache.known_vins()) == ["VIN1", "VIN2"]
+
+
+@pytest.mark.asyncio
+async def test_append_prepends_and_trims(hass):
+    """append() puts new trip at front, trims to max_size from the back."""
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.set("VIN1", [_trip("a"), _trip("b"), _trip("c")])
+    cache.append("VIN1", _trip("z"), max_size=3)
+    assert cache.get("VIN1") == [_trip("z"), _trip("a"), _trip("b")]
+
+
+@pytest.mark.asyncio
+async def test_append_below_max_does_not_trim(hass):
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.set("VIN1", [_trip("a"), _trip("b")])
+    cache.append("VIN1", _trip("z"), max_size=5)
+    assert cache.get("VIN1") == [_trip("z"), _trip("a"), _trip("b")]
+
+
+@pytest.mark.asyncio
+async def test_append_dedupes_existing_id(hass):
+    """Re-appending the same trip ID is a no-op (idempotent)."""
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.set("VIN1", [_trip("a"), _trip("b")])
+    cache.append("VIN1", _trip("a", label="duplicate"), max_size=5)
+    assert cache.get("VIN1") == [_trip("a"), _trip("b")]
+
+
+@pytest.mark.asyncio
+async def test_append_to_empty_creates(hass):
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.append("VIN1", _trip("a"), max_size=5)
+    assert cache.get("VIN1") == [_trip("a")]
+
+
+@pytest.mark.asyncio
+async def test_append_max_size_zero_is_noop(hass):
+    """max_size=0 means cache is disabled; append should not store anything."""
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.append("VIN1", _trip("a"), max_size=0)
+    assert cache.get("VIN1") == []
+
+
+@pytest.mark.asyncio
+async def test_trim_shrinks_to_size(hass):
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.set("VIN1", [_trip("a"), _trip("b"), _trip("c"), _trip("d"), _trip("e")])
+    cache.trim("VIN1", max_size=3)
+    assert cache.get("VIN1") == [_trip("a"), _trip("b"), _trip("c")]
+
+
+@pytest.mark.asyncio
+async def test_trim_zero_drops_entry(hass):
+    """trim(max_size=0) clears the VIN's slot entirely."""
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.set("VIN1", [_trip("a"), _trip("b")])
+    cache.trim("VIN1", max_size=0)
+    assert cache.get("VIN1") == []
+    assert "VIN1" not in cache.known_vins()
+
+
+@pytest.mark.asyncio
+async def test_trim_unknown_vin_is_noop(hass):
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.trim("VIN_UNKNOWN", max_size=3)
+    assert cache.get("VIN_UNKNOWN") == []
+
+
+@pytest.mark.asyncio
+async def test_trim_above_size_is_noop(hass):
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.set("VIN1", [_trip("a"), _trip("b")])
+    cache.trim("VIN1", max_size=5)
+    assert cache.get("VIN1") == [_trip("a"), _trip("b")]
+
+
+@pytest.mark.asyncio
+async def test_has_trip_id(hass):
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.set("VIN1", [_trip("a"), _trip("b")])
+    assert cache.has_trip_id("VIN1", "a") is True
+    assert cache.has_trip_id("VIN1", "b") is True
+    assert cache.has_trip_id("VIN1", "z") is False
+    assert cache.has_trip_id("VIN_UNKNOWN", "a") is False
+
+
+@pytest.mark.asyncio
+async def test_clear_drops_vin(hass):
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.set("VIN1", [_trip("a")])
+    cache.set("VIN2", [_trip("b")])
+    cache.clear("VIN1")
+    assert cache.get("VIN1") == []
+    assert cache.get("VIN2") == [_trip("b")]
+    assert cache.known_vins() == ["VIN2"]
+
+
+@pytest.mark.asyncio
+async def test_clear_unknown_vin_is_noop(hass):
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.clear("VIN_UNKNOWN")
+    # no exception raised

--- a/tests/test_trips_cache.py
+++ b/tests/test_trips_cache.py
@@ -189,3 +189,20 @@ async def test_clear_unknown_vin_is_noop(hass):
     await cache.load()
     cache.clear("VIN_UNKNOWN")
     # no exception raised
+
+
+@pytest.mark.asyncio
+async def test_prune_to_drops_unknown_vins(hass):
+    cache = TripsCacheStore(hass, "entry1")
+    await cache.load()
+    cache.set("VIN_KEEP", [_trip("a")])
+    cache.set("VIN_GONE", [_trip("b")])
+    mutated = cache.prune_to(["VIN_KEEP"])
+    assert mutated is True
+    assert cache.known_vins() == ["VIN_KEEP"]
+    # Idempotent.
+    assert cache.prune_to(["VIN_KEEP"]) is False
+    # Pruning to empty drops everything.
+    cache.set("VIN_OTHER", [_trip("c")])
+    assert cache.prune_to([]) is True
+    assert cache.known_vins() == []

--- a/tests/test_trips_manager.py
+++ b/tests/test_trips_manager.py
@@ -1,0 +1,349 @@
+"""Tests for RecentTripsManager (rolling-cache + delta-fetch orchestration)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.toyota.refresh_strategy import RefreshTrigger
+from custom_components.toyota.trips_manager import RecentTripsManager
+
+
+def _trip_dict(trip_id: str) -> dict:
+    """A pytoyoda _TripModel-shaped dict (post .model_dump(by_alias=True))."""
+    return {
+        "id": trip_id,
+        "summary": {
+            "startTs": f"2026-04-26T07:{trip_id[-2:].zfill(2)}:00Z",
+            "endTs": f"2026-04-26T07:{trip_id[-2:].zfill(2)}:30Z",
+            "startLat": 47.1,
+            "startLon": 20.2,
+            "endLat": 47.2,
+            "endLon": 20.3,
+            "length": 1000,
+            "duration": 600,
+        },
+        "hdc": None,
+        "scores": None,
+        "behaviours": None,
+        "route": [],
+    }
+
+
+def _wrap_as_trip(trip_dict: dict):
+    """Mimic pytoyoda's Trip wrapper: an object with `_trip` attr that has
+    `model_dump(by_alias=True)`. Tests use SimpleNamespace stubs that return
+    the dict directly when `model_dump` is called."""
+    inner = MagicMock()
+    inner.model_dump = MagicMock(return_value=trip_dict)
+    wrapper = SimpleNamespace(_trip=inner)
+    return wrapper
+
+
+def _make_vehicle(trip_dicts: list[dict], alias: str = "RAV4"):
+    """Build a Vehicle stub with `get_recent_trips` returning the supplied
+    pre-shaped trip dicts wrapped as Trip-like objects."""
+    captured: dict = {}
+
+    async def fake_get_recent_trips(limit, with_route=False, **_):
+        captured.update(limit=limit, with_route=with_route)
+        return [_wrap_as_trip(t) for t in trip_dicts[:limit]]
+
+    v = SimpleNamespace(
+        alias=alias,
+        get_recent_trips=AsyncMock(side_effect=fake_get_recent_trips),
+        _captured=captured,
+    )
+    return v
+
+
+def _make_decision(trigger: RefreshTrigger):
+    """Lightweight stand-in for RefreshDecision; manager only reads .trigger."""
+    return SimpleNamespace(trigger=trigger)
+
+
+def _make_entry(entry_id: str = "test_entry"):
+    return SimpleNamespace(entry_id=entry_id)
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_max_zero(hass):
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=0)
+    await mgr.async_setup()
+    v = _make_vehicle([_trip_dict("t1")])
+    await mgr.async_maybe_refresh(v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED))
+    v.get_recent_trips.assert_not_called()
+    assert mgr.cache.get("VIN1") == []
+
+
+@pytest.mark.asyncio
+async def test_cold_cache_seeds_with_max(hass):
+    """First refresh on empty cache fetches limit=max regardless of trigger."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    v = _make_vehicle(
+        [_trip_dict(f"t{i}") for i in range(10)],
+    )
+    await mgr.async_maybe_refresh(v, "VIN1", _make_decision(RefreshTrigger.NONE))
+    v.get_recent_trips.assert_called_once()
+    assert v._captured["limit"] == 5
+    assert v._captured["with_route"] is True
+    assert len(mgr.cache.get("VIN1")) == 5
+
+
+@pytest.mark.asyncio
+async def test_just_stopped_with_one_new_trip_appends(hass):
+    """JUST_STOPPED + delta-fetch sees 1 new + 1 cached → append the new one."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    # Pre-seed with a trip
+    mgr.cache.set("VIN1", [_trip_dict("cached")])
+    # Vehicle returns a NEW trip first, then the cached one (newest-first ordering)
+    v = _make_vehicle([_trip_dict("brand-new"), _trip_dict("cached")])
+    await mgr.async_maybe_refresh(
+        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED)
+    )
+    cached = mgr.cache.get("VIN1")
+    assert len(cached) == 2
+    assert cached[0]["id"] == "brand-new"
+    assert cached[1]["id"] == "cached"
+
+
+@pytest.mark.asyncio
+async def test_just_stopped_no_new_trip_no_op(hass):
+    """JUST_STOPPED + delta-fetch sees only cached trips → no change, mark for followup."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [_trip_dict("cached")])
+    v = _make_vehicle([_trip_dict("cached")])
+    await mgr.async_maybe_refresh(
+        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED)
+    )
+    assert len(mgr.cache.get("VIN1")) == 1
+    # Should have flagged followup pending
+    assert mgr._followup_pending.get("VIN1") is True
+
+
+@pytest.mark.asyncio
+async def test_just_stopped_followup_only_runs_when_pending(hass):
+    """JUST_STOPPED_FOLLOWUP without prior pending flag → no API call."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [_trip_dict("cached")])
+    v = _make_vehicle([_trip_dict("cached")])
+    await mgr.async_maybe_refresh(
+        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED_FOLLOWUP)
+    )
+    v.get_recent_trips.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_followup_fires_when_pending_and_picks_up_late_trip(hass):
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [_trip_dict("cached")])
+    mgr._followup_pending["VIN1"] = True
+    v = _make_vehicle([_trip_dict("late-arrival"), _trip_dict("cached")])
+    await mgr.async_maybe_refresh(
+        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED_FOLLOWUP)
+    )
+    cached = mgr.cache.get("VIN1")
+    assert len(cached) == 2
+    assert cached[0]["id"] == "late-arrival"
+    # Followup pending should be cleared after success
+    assert mgr._followup_pending.get("VIN1") is False
+
+
+@pytest.mark.asyncio
+async def test_gap_detected_triggers_full_refill(hass):
+    """JUST_STOPPED + both delta trips are new → gap → fall back to full reseed."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [_trip_dict("old")])
+    # Vehicle returns 5 new trips for the gap-fill seed call (after delta fetch
+    # of 2 returns 2 new and triggers refill).
+    v = _make_vehicle(
+        [
+            _trip_dict("newest"),
+            _trip_dict("newer"),
+            _trip_dict("new"),
+            _trip_dict("less-new"),
+            _trip_dict("least-new"),
+        ]
+    )
+    await mgr.async_maybe_refresh(
+        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED)
+    )
+    # Should have called twice: limit=2 (delta), then limit=5 (full reseed)
+    assert v.get_recent_trips.call_count == 2
+    cached = mgr.cache.get("VIN1")
+    assert len(cached) == 5
+    assert cached[0]["id"] == "newest"
+
+
+@pytest.mark.asyncio
+async def test_other_triggers_are_noop(hass):
+    """Triggers that aren't stop-related don't fetch."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [_trip_dict("cached")])
+    v = _make_vehicle([_trip_dict("brand-new")])
+    for trigger in [
+        RefreshTrigger.NONE,
+        RefreshTrigger.IDLE_WAKE,
+        RefreshTrigger.CACHE_STALE,
+        RefreshTrigger.CURRENTLY_MOVING,
+    ]:
+        await mgr.async_maybe_refresh(v, "VIN1", _make_decision(trigger))
+    v.get_recent_trips.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_service_refresh_replaces_cache(hass):
+    """Service call discards cache and refetches limit=N."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [_trip_dict("a"), _trip_dict("b"), _trip_dict("c")])
+    v = _make_vehicle([_trip_dict("fresh1"), _trip_dict("fresh2")])
+    count = await mgr.async_service_refresh("VIN1", v, limit=2)
+    assert count == 2
+    cached = mgr.cache.get("VIN1")
+    assert [t["id"] for t in cached] == ["fresh1", "fresh2"]
+
+
+@pytest.mark.asyncio
+async def test_service_refresh_works_when_max_zero(hass):
+    """Service call works regardless of max_recent_trips config."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=0)
+    await mgr.async_setup()
+    v = _make_vehicle([_trip_dict("a"), _trip_dict("b"), _trip_dict("c")])
+    count = await mgr.async_service_refresh("VIN1", v, limit=3)
+    assert count == 3
+
+
+@pytest.mark.asyncio
+async def test_service_refresh_rejects_invalid_limit(hass):
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    v = _make_vehicle([])
+    with pytest.raises(ValueError, match="limit must be between 1 and 50"):
+        await mgr.async_service_refresh("VIN1", v, limit=0)
+    with pytest.raises(ValueError, match="limit must be between 1 and 50"):
+        await mgr.async_service_refresh("VIN1", v, limit=51)
+
+
+@pytest.mark.asyncio
+async def test_update_max_lowered_trims(hass):
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=10)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [_trip_dict(f"t{i}") for i in range(8)])
+    mutated = mgr.update_max(3)
+    assert mutated is True
+    assert len(mgr.cache.get("VIN1")) == 3
+    assert mgr.max_recent_trips == 3
+
+
+@pytest.mark.asyncio
+async def test_update_max_raised_no_mutation(hass):
+    """Raising max doesn't trim or refetch; the cold-start branch handles fill."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=3)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [_trip_dict(f"t{i}") for i in range(3)])
+    mutated = mgr.update_max(10)
+    assert mutated is False
+    assert len(mgr.cache.get("VIN1")) == 3
+    assert mgr.max_recent_trips == 10
+
+
+@pytest.mark.asyncio
+async def test_update_max_to_zero_drops_entries(hass):
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [_trip_dict("a"), _trip_dict("b")])
+    mgr.cache.set("VIN2", [_trip_dict("c")])
+    mutated = mgr.update_max(0)
+    assert mutated is True
+    assert mgr.cache.get("VIN1") == []
+    assert mgr.cache.get("VIN2") == []
+
+
+@pytest.mark.asyncio
+async def test_update_max_unchanged_no_mutation(hass):
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [_trip_dict("a")])
+    mutated = mgr.update_max(5)
+    assert mutated is False
+    assert len(mgr.cache.get("VIN1")) == 1
+
+
+@pytest.mark.asyncio
+async def test_setup_trims_to_max_on_load(hass):
+    """Cache loaded from disk with more trips than the new max gets trimmed.
+
+    Covers the options-flow-lowered-max + reload sequence: fresh manager
+    with new (lower) max loads the on-disk cache that was written with the
+    old (higher) max, and trims back to the new ceiling on async_setup.
+    """
+    # Pre-seed the on-disk cache with 10 trips via a manager configured
+    # at max=10, then save.
+    seed_mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=10)
+    await seed_mgr.async_setup()
+    seed_mgr.cache.set("VIN1", [_trip_dict(f"t{i}") for i in range(10)])
+    await seed_mgr.cache.save()
+
+    # New manager with lower max picks up the 10-trip cache and trims to 4.
+    new_mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=4)
+    await new_mgr.async_setup()
+    assert len(new_mgr.cache.get("VIN1")) == 4
+
+
+@pytest.mark.asyncio
+async def test_underfilled_on_load_seeds_once(hass):
+    """Cache loaded with fewer trips than the new max triggers a one-shot seed.
+
+    Covers the options-flow-raised-max + reload sequence: fresh manager with
+    new (higher) max loads an on-disk cache written at the old (lower) max.
+    The first refresh tick should seed up to the new ceiling, regardless of
+    trigger. Subsequent ticks fall through to normal delta-fetch behaviour.
+    """
+    # Pre-seed disk with 5 trips via a manager configured at max=5.
+    seed_mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await seed_mgr.async_setup()
+    seed_mgr.cache.set("VIN1", [_trip_dict(f"old{i}") for i in range(5)])
+    await seed_mgr.cache.save()
+
+    # New manager with raised max picks up the 5-trip cache.
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=10)
+    await mgr.async_setup()
+    assert len(mgr.cache.get("VIN1")) == 5  # not trimmed (already <= max)
+    assert "VIN1" in mgr._underfilled_vins
+
+    # First refresh tick should seed with limit=max=10, regardless of trigger.
+    v = _make_vehicle([_trip_dict(f"fresh{i}") for i in range(10)])
+    await mgr.async_maybe_refresh(v, "VIN1", _make_decision(RefreshTrigger.NONE))
+    v.get_recent_trips.assert_called_once()
+    assert v._captured["limit"] == 10
+    assert len(mgr.cache.get("VIN1")) == 10
+    # Underfill flag should be cleared after one-shot refill.
+    assert "VIN1" not in mgr._underfilled_vins
+
+    # Subsequent NONE-trigger tick should NOT call the API (steady state).
+    v.get_recent_trips.reset_mock()
+    await mgr.async_maybe_refresh(v, "VIN1", _make_decision(RefreshTrigger.NONE))
+    v.get_recent_trips.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_seed_failure_leaves_cache_empty(hass):
+    """If get_recent_trips raises, cache stays empty rather than partial."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    v = SimpleNamespace(
+        alias="RAV4",
+        get_recent_trips=AsyncMock(side_effect=Exception("API down")),
+    )
+    await mgr.async_maybe_refresh(v, "VIN1", _make_decision(RefreshTrigger.NONE))
+    assert mgr.cache.get("VIN1") == []

--- a/tests/test_trips_manager.py
+++ b/tests/test_trips_manager.py
@@ -35,18 +35,30 @@ def _trip_dict(trip_id: str) -> dict:
 
 def _wrap_as_trip(trip_dict: dict):
     """Mimic pytoyoda's Trip wrapper: an object with `_trip` attr that has
-    `model_dump(by_alias=True)`. Tests use SimpleNamespace stubs that return
-    the dict directly when `model_dump` is called.
+    `model_dump(by_alias=True)` and an `id` matching the dict's id field.
     """
     inner = MagicMock()
     inner.model_dump = MagicMock(return_value=trip_dict)
+    inner.id = trip_dict.get("id")
     wrapper = SimpleNamespace(_trip=inner)
     return wrapper
 
 
-def _make_vehicle(trip_dicts: list[dict], alias: str = "RAV4"):
+def _make_vehicle(
+    trip_dicts: list[dict],
+    alias: str = "RAV4",
+    *,
+    trip_history=None,
+):
     """Build a Vehicle stub with `get_recent_trips` returning the supplied
     pre-shaped trip dicts wrapped as Trip-like objects.
+
+    By default ``trip_history`` mirrors ``trip_dicts[:1]`` wrapped, matching
+    the production shape where pytoyoda's per-cycle trip_history endpoint
+    returns the most recent trip with summary=True/route=False. Pass
+    ``trip_history=...`` to override (e.g. ``[]`` for the AYGO no-trips
+    path, ``None`` for the endpoint-failed path, or a custom Trip wrapper
+    list to model id mismatch with the cache).
     """
     captured: dict = {}
 
@@ -54,9 +66,15 @@ def _make_vehicle(trip_dicts: list[dict], alias: str = "RAV4"):
         captured.update(limit=limit, with_route=with_route)
         return [_wrap_as_trip(t) for t in trip_dicts[:limit]]
 
+    if trip_history is None and trip_dicts:
+        trip_history = [_wrap_as_trip(trip_dicts[0])]
+    elif trip_history is None:
+        trip_history = []
+
     v = SimpleNamespace(
         alias=alias,
         get_recent_trips=AsyncMock(side_effect=fake_get_recent_trips),
+        trip_history=trip_history,
         _captured=captured,
     )
     return v
@@ -299,9 +317,12 @@ async def test_seed_failure_leaves_cache_empty(hass):
     """If get_recent_trips raises, cache stays empty rather than partial."""
     mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
     await mgr.async_setup()
+    # trip_history non-empty so piggyback gate doesn't short-circuit;
+    # we want to reach get_recent_trips and have it raise.
     v = SimpleNamespace(
         alias="RAV4",
         get_recent_trips=AsyncMock(side_effect=Exception("API down")),
+        trip_history=[_wrap_as_trip(_trip_dict("would-have-fetched"))],
     )
     await mgr.async_maybe_refresh(v, "VIN1", _make_decision(RefreshTrigger.NONE))
     assert mgr.cache.get("VIN1") == []
@@ -343,7 +364,15 @@ async def test_concurrent_service_and_tick_serialise(hass):
         await fetch_release.wait()
         return [_wrap_as_trip(_trip_dict(f"t{i}")) for i in range(limit)]
 
-    v = SimpleNamespace(alias="RAV4", get_recent_trips=AsyncMock(side_effect=slow_fetch))
+    # trip_history shows a NEW trip (not in the cache the service call seeds),
+    # so the tick's piggyback gate routes through the delta-fetch path rather
+    # than skipping. Without this the tick would short-circuit and we'd lose
+    # the lock-serialisation assertion's signal.
+    v = SimpleNamespace(
+        alias="RAV4",
+        get_recent_trips=AsyncMock(side_effect=slow_fetch),
+        trip_history=[_wrap_as_trip(_trip_dict("brand-new-after-service"))],
+    )
 
     service_task = asyncio.create_task(mgr.async_service_refresh("VIN1", v, limit=5))
     await fetch_started.wait()
@@ -376,3 +405,135 @@ async def test_async_prune_orphans_drops_unknown_vins(hass):
     # Idempotent.
     mutated2 = await mgr.async_prune_orphans(["VIN_KEEP"])
     assert mutated2 is False
+
+
+# ---------------------------------------------------------------------------
+# Piggyback gating tests
+# ---------------------------------------------------------------------------
+# These exercise the cycle's free `vehicle.trip_history` signal as a gate
+# on the heavier `get_recent_trips(with_route=True)` fetch. See
+# trips_manager.async_maybe_refresh docstring + 2026-05-07 journal.
+
+
+@pytest.mark.asyncio
+async def test_piggyback_empty_trip_history_skips_fetch(hass):
+    """AYGO path: vehicle has no trips data → skip fetch entirely."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    v = _make_vehicle([], trip_history=[])
+    await mgr.async_maybe_refresh(
+        v, "VIN_AYGO", _make_decision(RefreshTrigger.JUST_STOPPED),
+    )
+    v.get_recent_trips.assert_not_called()
+    assert mgr.cache.get("VIN_AYGO") == []
+
+
+@pytest.mark.asyncio
+async def test_piggyback_none_trip_history_skips_fetch(hass):
+    """trip_history endpoint failed this cycle → conservative skip."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    v = _make_vehicle([_trip_dict("t1")], trip_history=None)
+    # The _make_vehicle helper synthesises a trip_history when
+    # trip_history=None is passed AND trip_dicts is non-empty. Override
+    # here to force the "endpoint failed" shape.
+    v.trip_history = None
+    await mgr.async_maybe_refresh(
+        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED),
+    )
+    v.get_recent_trips.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_piggyback_matching_id_skips_delta_and_arms_followup(hass):
+    """Cache top id == trip_history top id on JUST_STOPPED → skip + flag followup.
+
+    Toyota's summary endpoint may also be lagging behind a freshly-driven
+    trip. Setting followup_pending lets the next stop tick reach the
+    delta-fetch path if a new trip eventually surfaces.
+    """
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [_trip_dict("cached")])
+    v = _make_vehicle([_trip_dict("cached")])  # default trip_history → cached
+    await mgr.async_maybe_refresh(
+        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED),
+    )
+    v.get_recent_trips.assert_not_called()
+    assert mgr._followup_pending.get("VIN1") is True
+
+
+@pytest.mark.asyncio
+async def test_piggyback_matching_id_on_non_stop_does_not_arm_followup(hass):
+    """Steady-state matching id should NOT arm followup-pending."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [_trip_dict("cached")])
+    v = _make_vehicle([_trip_dict("cached")])
+    await mgr.async_maybe_refresh(
+        v, "VIN1", _make_decision(RefreshTrigger.NONE),
+    )
+    v.get_recent_trips.assert_not_called()
+    assert mgr._followup_pending.get("VIN1") in (None, False)
+
+
+@pytest.mark.asyncio
+async def test_piggyback_new_id_triggers_delta_on_stop(hass):
+    """trip_history shows a new trip → delta-fetch fires on JUST_STOPPED."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [_trip_dict("cached")])
+    v = _make_vehicle(
+        [_trip_dict("brand-new"), _trip_dict("cached")],
+        trip_history=[_wrap_as_trip(_trip_dict("brand-new"))],
+    )
+    await mgr.async_maybe_refresh(
+        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED),
+    )
+    v.get_recent_trips.assert_called_once()
+    assert v._captured["limit"] == 2  # delta-fetch
+    cached = mgr.cache.get("VIN1")
+    assert cached[0]["id"] == "brand-new"
+    assert cached[1]["id"] == "cached"
+
+
+@pytest.mark.asyncio
+async def test_piggyback_cold_start_when_history_has_trips(hass):
+    """Empty cache + trip_history non-empty → cold-start fires."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    v = _make_vehicle([_trip_dict(f"t{i}") for i in range(3)])
+    await mgr.async_maybe_refresh(
+        v, "VIN1", _make_decision(RefreshTrigger.NONE),
+    )
+    v.get_recent_trips.assert_called_once()
+    assert v._captured["limit"] == 5  # cold-start uses max
+    assert v._captured["with_route"] is True
+
+
+@pytest.mark.asyncio
+async def test_piggyback_uuid_id_compares_as_string(hass):
+    """pytoyoda Trip._trip.id is a UUID; cache stores str. Compare must align."""
+    from uuid import UUID
+
+    trip_uuid = UUID("49743b6d-3078-4efe-a68f-6c826b2680b6")
+    cached_dict = {**_trip_dict("ignored"), "id": str(trip_uuid)}
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [cached_dict])
+
+    # Simulate pytoyoda: history[0]._trip.id is the UUID object itself.
+    inner = MagicMock()
+    inner.id = trip_uuid
+    history_wrapper = SimpleNamespace(_trip=inner)
+    v = SimpleNamespace(
+        alias="RAV4",
+        get_recent_trips=AsyncMock(),
+        trip_history=[history_wrapper],
+    )
+    await mgr.async_maybe_refresh(
+        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED),
+    )
+    # UUID stringified == cache id string → match → no fetch.
+    v.get_recent_trips.assert_not_called()
+    assert mgr._followup_pending.get("VIN1") is True

--- a/tests/test_trips_manager.py
+++ b/tests/test_trips_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -35,7 +36,8 @@ def _trip_dict(trip_id: str) -> dict:
 def _wrap_as_trip(trip_dict: dict):
     """Mimic pytoyoda's Trip wrapper: an object with `_trip` attr that has
     `model_dump(by_alias=True)`. Tests use SimpleNamespace stubs that return
-    the dict directly when `model_dump` is called."""
+    the dict directly when `model_dump` is called.
+    """
     inner = MagicMock()
     inner.model_dump = MagicMock(return_value=trip_dict)
     wrapper = SimpleNamespace(_trip=inner)
@@ -44,7 +46,8 @@ def _wrap_as_trip(trip_dict: dict):
 
 def _make_vehicle(trip_dicts: list[dict], alias: str = "RAV4"):
     """Build a Vehicle stub with `get_recent_trips` returning the supplied
-    pre-shaped trip dicts wrapped as Trip-like objects."""
+    pre-shaped trip dicts wrapped as Trip-like objects.
+    """
     captured: dict = {}
 
     async def fake_get_recent_trips(limit, with_route=False, **_):
@@ -103,7 +106,7 @@ async def test_just_stopped_with_one_new_trip_appends(hass):
     # Vehicle returns a NEW trip first, then the cached one (newest-first ordering)
     v = _make_vehicle([_trip_dict("brand-new"), _trip_dict("cached")])
     await mgr.async_maybe_refresh(
-        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED)
+        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED),
     )
     cached = mgr.cache.get("VIN1")
     assert len(cached) == 2
@@ -119,7 +122,7 @@ async def test_just_stopped_no_new_trip_no_op(hass):
     mgr.cache.set("VIN1", [_trip_dict("cached")])
     v = _make_vehicle([_trip_dict("cached")])
     await mgr.async_maybe_refresh(
-        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED)
+        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED),
     )
     assert len(mgr.cache.get("VIN1")) == 1
     # Should have flagged followup pending
@@ -134,7 +137,7 @@ async def test_just_stopped_followup_only_runs_when_pending(hass):
     mgr.cache.set("VIN1", [_trip_dict("cached")])
     v = _make_vehicle([_trip_dict("cached")])
     await mgr.async_maybe_refresh(
-        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED_FOLLOWUP)
+        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED_FOLLOWUP),
     )
     v.get_recent_trips.assert_not_called()
 
@@ -147,7 +150,7 @@ async def test_followup_fires_when_pending_and_picks_up_late_trip(hass):
     mgr._followup_pending["VIN1"] = True
     v = _make_vehicle([_trip_dict("late-arrival"), _trip_dict("cached")])
     await mgr.async_maybe_refresh(
-        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED_FOLLOWUP)
+        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED_FOLLOWUP),
     )
     cached = mgr.cache.get("VIN1")
     assert len(cached) == 2
@@ -171,10 +174,10 @@ async def test_gap_detected_triggers_full_refill(hass):
             _trip_dict("new"),
             _trip_dict("less-new"),
             _trip_dict("least-new"),
-        ]
+        ],
     )
     await mgr.async_maybe_refresh(
-        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED)
+        v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED),
     )
     # Should have called twice: limit=2 (delta), then limit=5 (full reseed)
     assert v.get_recent_trips.call_count == 2
@@ -232,51 +235,6 @@ async def test_service_refresh_rejects_invalid_limit(hass):
         await mgr.async_service_refresh("VIN1", v, limit=0)
     with pytest.raises(ValueError, match="limit must be between 1 and 50"):
         await mgr.async_service_refresh("VIN1", v, limit=51)
-
-
-@pytest.mark.asyncio
-async def test_update_max_lowered_trims(hass):
-    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=10)
-    await mgr.async_setup()
-    mgr.cache.set("VIN1", [_trip_dict(f"t{i}") for i in range(8)])
-    mutated = mgr.update_max(3)
-    assert mutated is True
-    assert len(mgr.cache.get("VIN1")) == 3
-    assert mgr.max_recent_trips == 3
-
-
-@pytest.mark.asyncio
-async def test_update_max_raised_no_mutation(hass):
-    """Raising max doesn't trim or refetch; the cold-start branch handles fill."""
-    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=3)
-    await mgr.async_setup()
-    mgr.cache.set("VIN1", [_trip_dict(f"t{i}") for i in range(3)])
-    mutated = mgr.update_max(10)
-    assert mutated is False
-    assert len(mgr.cache.get("VIN1")) == 3
-    assert mgr.max_recent_trips == 10
-
-
-@pytest.mark.asyncio
-async def test_update_max_to_zero_drops_entries(hass):
-    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
-    await mgr.async_setup()
-    mgr.cache.set("VIN1", [_trip_dict("a"), _trip_dict("b")])
-    mgr.cache.set("VIN2", [_trip_dict("c")])
-    mutated = mgr.update_max(0)
-    assert mutated is True
-    assert mgr.cache.get("VIN1") == []
-    assert mgr.cache.get("VIN2") == []
-
-
-@pytest.mark.asyncio
-async def test_update_max_unchanged_no_mutation(hass):
-    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
-    await mgr.async_setup()
-    mgr.cache.set("VIN1", [_trip_dict("a")])
-    mutated = mgr.update_max(5)
-    assert mutated is False
-    assert len(mgr.cache.get("VIN1")) == 1
 
 
 @pytest.mark.asyncio
@@ -347,3 +305,74 @@ async def test_seed_failure_leaves_cache_empty(hass):
     )
     await mgr.async_maybe_refresh(v, "VIN1", _make_decision(RefreshTrigger.NONE))
     assert mgr.cache.get("VIN1") == []
+
+
+@pytest.mark.asyncio
+async def test_service_refresh_failure_preserves_prior_cache(hass):
+    """Service-call fetch failure must not nuke the existing cache."""
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    mgr.cache.set("VIN1", [_trip_dict("kept1"), _trip_dict("kept2")])
+    v = SimpleNamespace(
+        alias="RAV4",
+        get_recent_trips=AsyncMock(side_effect=Exception("API down")),
+    )
+    count = await mgr.async_service_refresh("VIN1", v, limit=5)
+    assert count == 2
+    assert [t["id"] for t in mgr.cache.get("VIN1")] == ["kept1", "kept2"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_service_and_tick_serialise(hass):
+    """Service call and coordinator tick on the same VIN must serialise.
+
+    Without the per-VIN lock the cold-start branch in async_maybe_refresh sees
+    the cache cleared by async_service_refresh and issues a duplicate fetch.
+    """
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+
+    call_count = 0
+    fetch_started = asyncio.Event()
+    fetch_release = asyncio.Event()
+
+    async def slow_fetch(limit, with_route=False, **_):
+        nonlocal call_count
+        call_count += 1
+        fetch_started.set()
+        await fetch_release.wait()
+        return [_wrap_as_trip(_trip_dict(f"t{i}")) for i in range(limit)]
+
+    v = SimpleNamespace(alias="RAV4", get_recent_trips=AsyncMock(side_effect=slow_fetch))
+
+    service_task = asyncio.create_task(mgr.async_service_refresh("VIN1", v, limit=5))
+    await fetch_started.wait()
+    # Service call holds the lock + is mid-fetch. Coordinator tick fires now.
+    tick_task = asyncio.create_task(
+        mgr.async_maybe_refresh(v, "VIN1", _make_decision(RefreshTrigger.JUST_STOPPED)),
+    )
+    # Give the tick a chance to run; it should be blocked on the lock.
+    await asyncio.sleep(0)
+    fetch_release.set()
+    await asyncio.gather(service_task, tick_task)
+
+    # Service did one fetch. Tick saw a populated cache (via the lock) and
+    # took the steady-state JUST_STOPPED -> delta-fetch path: one more call.
+    # Pre-fix this would be 3 calls (service + cold-start tick + delta) or
+    # corrupted state.
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_prune_orphans_drops_unknown_vins(hass):
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await mgr.async_setup()
+    mgr.cache.set("VIN_KEEP", [_trip_dict("a")])
+    mgr.cache.set("VIN_GONE", [_trip_dict("b")])
+    mutated = await mgr.async_prune_orphans(["VIN_KEEP"])
+    assert mutated is True
+    assert mgr.cache.get("VIN_KEEP") == [_trip_dict("a")]
+    assert mgr.cache.get("VIN_GONE") == []
+    # Idempotent.
+    mutated2 = await mgr.async_prune_orphans(["VIN_KEEP"])
+    assert mutated2 is False

--- a/tests/test_trips_manager.py
+++ b/tests/test_trips_manager.py
@@ -313,6 +313,35 @@ async def test_underfilled_on_load_seeds_once(hass):
 
 
 @pytest.mark.asyncio
+async def test_underfilled_flag_survives_failed_refill(hass):
+    """A failed one-shot refill keeps the underfill flag armed for retry."""
+    seed_mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
+    await seed_mgr.async_setup()
+    seed_mgr.cache.set("VIN1", [_trip_dict(f"old{i}") for i in range(5)])
+    await seed_mgr.cache.save()
+
+    mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=10)
+    await mgr.async_setup()
+    assert "VIN1" in mgr._underfilled_vins
+
+    # Refill attempt fails: flag must stay armed, cache untouched.
+    bad = SimpleNamespace(
+        alias="RAV4",
+        get_recent_trips=AsyncMock(side_effect=Exception("API down")),
+        trip_history=[_wrap_as_trip(_trip_dict("old0"))],
+    )
+    await mgr.async_maybe_refresh(bad, "VIN1", _make_decision(RefreshTrigger.NONE))
+    assert "VIN1" in mgr._underfilled_vins
+    assert len(mgr.cache.get("VIN1")) == 5
+
+    # Next cycle succeeds: refill lands, flag clears.
+    good = _make_vehicle([_trip_dict(f"fresh{i}") for i in range(10)])
+    await mgr.async_maybe_refresh(good, "VIN1", _make_decision(RefreshTrigger.NONE))
+    assert "VIN1" not in mgr._underfilled_vins
+    assert len(mgr.cache.get("VIN1")) == 10
+
+
+@pytest.mark.asyncio
 async def test_seed_failure_leaves_cache_empty(hass):
     """If get_recent_trips raises, cache stays empty rather than partial."""
     mgr = RecentTripsManager(hass, _make_entry(), max_recent_trips=5)
@@ -513,7 +542,7 @@ async def test_piggyback_cold_start_when_history_has_trips(hass):
 
 @pytest.mark.asyncio
 async def test_piggyback_uuid_id_compares_as_string(hass):
-    """pytoyoda Trip._trip.id is a UUID; cache stores str. Compare must align."""
+    """Pytoyoda Trip._trip.id is a UUID; cache stores str. Compare must align."""
     from uuid import UUID
 
     trip_uuid = UUID("49743b6d-3078-4efe-a68f-6c826b2680b6")

--- a/tests/test_trips_transform.py
+++ b/tests/test_trips_transform.py
@@ -1,0 +1,215 @@
+"""Tests for trips_transform.to_card_shape (pytoyoda _TripModel -> card Trip)."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.toyota.trips_transform import to_card_shape
+
+
+def _full_trip_dict() -> dict:
+    """A complete RAV4 PHEV trip with summary, hdc, scores, behaviours, route."""
+    return {
+        "id": "trip-uuid-1",
+        "summary": {
+            "startTs": "2026-04-26T07:06:45Z",
+            "endTs": "2026-04-26T07:15:54Z",
+            "startLat": 47.1652,
+            "startLon": 20.2178,
+            "endLat": 47.1927,
+            "endLon": 20.1938,
+            "length": 4943,
+            "duration": 549,
+            "durationIdle": 30,
+            "maxSpeed": 67,
+            "averageSpeed": 32.4,
+            "fuelConsumption": 275,
+            "lengthOverspeed": 0,
+            "durationOverspeed": 0,
+            "lengthHighway": 0,
+            "durationHighway": 0,
+            "countries": ["HU"],
+            "nightTrip": False,
+        },
+        "hdc": {
+            "evTime": 291,
+            "evDistance": 2379,
+            "chargeTime": 0,
+            "chargeDist": 0,
+            "ecoTime": 0,
+            "ecoDist": 0,
+            "powerTime": 0,
+            "powerDist": 0,
+        },
+        "scores": {"acceleration": 90, "braking": 71, "global": 81},
+        "behaviours": [
+            {"lat": 47.1642, "lon": 20.2029, "type": "A", "good": True}
+        ],
+        "route": [
+            {"lat": 47.1652, "lon": 20.2178, "isEv": True, "overspeed": False},
+            {"lat": 47.1927, "lon": 20.1938, "isEv": False, "overspeed": False},
+        ],
+    }
+
+
+def _aygo_trip_dict() -> dict:
+    """ICE-only (no hdc, no scores, no behaviours) - mirrors AYGO shape."""
+    return {
+        "id": "trip-uuid-2",
+        "summary": {
+            "startTs": "2026-04-26T08:00:00Z",
+            "endTs": "2026-04-26T08:10:00Z",
+            "startLat": 47.5,
+            "startLon": 19.0,
+            "endLat": 47.6,
+            "endLon": 19.1,
+            "length": 5000,
+            "duration": 600,
+        },
+        "hdc": None,
+        "scores": None,
+        "behaviours": None,
+        "route": [
+            {"lat": 47.5, "lon": 19.0},
+            {"lat": 47.6, "lon": 19.1},
+        ],
+    }
+
+
+def test_basic_top_level_fields():
+    out = to_card_shape(_full_trip_dict(), "RAV4")
+    assert out["id"] == "trip-uuid-1"
+    assert out["source"] == "rav4"
+    assert out["activity_type"] == "drive"
+    assert out["start_ts"] == "2026-04-26T07:06:45Z"
+    assert out["end_ts"] == "2026-04-26T07:15:54Z"
+
+
+def test_start_end_coords():
+    out = to_card_shape(_full_trip_dict(), "RAV4")
+    assert out["start"] == {"lat": 47.1652, "lon": 20.2178}
+    assert out["end"] == {"lat": 47.1927, "lon": 20.1938}
+
+
+def test_route_keeps_optional_flags():
+    out = to_card_shape(_full_trip_dict(), "RAV4")
+    assert len(out["route"]) == 2
+    assert out["route"][0] == {
+        "lat": 47.1652, "lon": 20.2178, "isEv": True, "overspeed": False,
+    }
+
+
+def test_route_drops_points_missing_lat_or_lon():
+    trip = _aygo_trip_dict()
+    trip["route"] = [
+        {"lat": 47.5, "lon": 19.0},
+        {"lat": None, "lon": 19.1},  # bad
+        {"lat": 47.6, "lon": None},  # bad
+        {"lat": 47.6, "lon": 19.1},
+    ]
+    out = to_card_shape(trip, "AYGO")
+    assert len(out["route"]) == 2
+    assert all("lat" in p and "lon" in p for p in out["route"])
+
+
+def test_stats_includes_phev_fields_for_rav4():
+    out = to_card_shape(_full_trip_dict(), "RAV4")
+    s = out["stats"]
+    assert s["distance_m"] == 4943
+    assert s["duration_s"] == 549
+    assert s["max_speed_kmh"] == 67
+    assert s["average_speed_kmh"] == 32.4
+    assert s["fuel_consumption_ml"] == 275
+    assert s["ev_time_s"] == 291
+    assert s["ev_distance_m"] == 2379
+
+
+def test_stats_drops_phev_fields_for_aygo():
+    """Q3 acceptance: hdc=None means no ev_*/charge_*/eco_*/power_* keys."""
+    out = to_card_shape(_aygo_trip_dict(), "AYGO")
+    s = out["stats"]
+    assert "ev_time_s" not in s
+    assert "ev_distance_m" not in s
+    assert "charge_time_s" not in s
+    assert "eco_time_s" not in s
+    assert "power_time_s" not in s
+    # Summary fields still present
+    assert s["distance_m"] == 5000
+    assert s["duration_s"] == 600
+
+
+def test_stats_drops_summary_fields_when_none():
+    """Toyota sometimes returns partial summary; missing fields not set to None."""
+    trip = _aygo_trip_dict()
+    trip["summary"]["fuelConsumption"] = None  # explicitly None
+    # maxSpeed is absent from the dict entirely
+    out = to_card_shape(trip, "AYGO")
+    s = out["stats"]
+    assert "fuel_consumption_ml" not in s
+    assert "max_speed_kmh" not in s
+
+
+def test_scores_dropped_when_absent():
+    """Q3: scores=None means the trip dict has no 'scores' key."""
+    out = to_card_shape(_aygo_trip_dict(), "AYGO")
+    assert "scores" not in out
+
+
+def test_scores_included_when_present():
+    out = to_card_shape(_full_trip_dict(), "RAV4")
+    assert out["scores"] == {"acceleration": 90, "braking": 71, "global": 81}
+
+
+def test_behaviours_dropped_when_absent():
+    out = to_card_shape(_aygo_trip_dict(), "AYGO")
+    assert "behaviours" not in out
+
+
+def test_behaviours_included_when_present():
+    out = to_card_shape(_full_trip_dict(), "RAV4")
+    assert len(out["behaviours"]) == 1
+    assert out["behaviours"][0]["type"] == "A"
+
+
+def test_returns_none_when_summary_missing():
+    """Defensive: untransformable trip yields None, caller decides what to do."""
+    trip = {"id": "trip-uuid-3", "summary": None}
+    assert to_card_shape(trip, "RAV4") is None
+    trip2 = {"id": "trip-uuid-4"}  # no summary key at all
+    assert to_card_shape(trip2, "RAV4") is None
+
+
+def test_empty_route_yields_empty_route_list():
+    trip = _aygo_trip_dict()
+    trip["route"] = []
+    out = to_card_shape(trip, "AYGO")
+    assert out["route"] == []
+
+
+def test_route_none_yields_empty_route_list():
+    trip = _aygo_trip_dict()
+    trip["route"] = None
+    out = to_card_shape(trip, "AYGO")
+    assert out["route"] == []
+
+
+def test_alias_lowercased_for_source():
+    out = to_card_shape(_aygo_trip_dict(), "MyRav4")
+    assert out["source"] == "myrav4"
+
+
+def test_alias_none_defaults_to_toyota():
+    out = to_card_shape(_aygo_trip_dict(), None)
+    assert out["source"] == "toyota"
+
+
+def test_route_optional_flags_with_none_dropped():
+    """If a route point has explicit None for an optional flag, drop it."""
+    trip = _aygo_trip_dict()
+    trip["route"] = [
+        {"lat": 47.5, "lon": 19.0, "isEv": None, "overspeed": True},
+    ]
+    out = to_card_shape(trip, "AYGO")
+    pt = out["route"][0]
+    assert "isEv" not in pt
+    assert pt["overspeed"] is True


### PR DESCRIPTION
## What

A **recent trips** feature: per-vehicle rolling cache of the last N trips, surfaced as `sensor.<alias>_recent_trips` (state = trip count, `attributes.trips[]` = slim per-trip metadata), plus:

- **`toyota.refresh_recent_trips` service** + a per-vehicle button - works even with auto-fetch disabled, so users can drive on-demand fetches from automations.
- **`toyota.get_trip_route` service** (`SupportsResponse.ONLY`) - returns the full route polyline for one trip on demand. The sensor attributes deliberately carry route *metadata only* (`route_point_count`), mirroring HA core's 2024.x weather-forecast pattern: state stays small, bulk is fetched lazily.
- **`max_recent_trips` option** (default **0 = feature off**, 1-20). Zero behaviour change for existing users.

## Design: rate-limit-conscious by construction

The trips endpoint is Toyota's flakiest surface, so the manager never polls it blindly:

- **Piggyback gating**: each coordinator cycle already fetches `trip_history` (`/v1/trips?summary=True&limit=1&route=False`). Its top trip id is compared against the cache top - a fetch happens only when Toyota actually has a trip we don't, and only on smart-strategy stop-event ticks (`just_stopped` + conditional follow-up for delayed ingest). A vehicle with no trips data at all (e.g. Toyota Connect Lite tier) costs zero extra requests.
- **Store-backed cache** survives HA restarts and config-entry reloads; per-VIN `asyncio.Lock` serializes coordinator vs service/button refreshes; orphaned VINs are pruned; a failed service refresh preserves the previous cache instead of clearing it.

## Field results (~2 months live on a 2-vehicle setup)

- Sensor attribute payload for 10 trips: **566,455 -> 8,422 bytes (67x)**; the recorder's 16 KiB warning went silent.
- Trip-less vehicle (AYGO X): **0 trips calls per cycle** (was ~10 wasted fetches/day at 6-min polling).
- `get_trip_route`: 513-point route in a 91 KB response on demand; unknown id returns `{found: false}`.
- Cache verified intact across restarts, reloads and the recent endpoint-migration turbulence.

## Dependency

Runtime needs `Vehicle.get_recent_trips()` from pytoyoda/pytoyoda#253 (ready for review). The tests here are mock-based and pass on any pytoyoda; the manifest pin stays untouched in this PR and should be bumped once #253 ships in a release. Suggested order: merge #253 -> pytoyoda release -> one-line manifest bump here.

## What's next

I'm also building a Lovelace card (journey viewer: paginated trip list + route map, fed by exactly this sensor's `attributes.trips[]` + `toyota.get_trip_route` contract). It will be published separately once polished - the sensor stands on its own (the attributes are plain, documented data), the card is just the first consumer.

## Tests

63 new tests (94 total): manager lifecycle (cold start, delta-fetch, follow-up arming, under-filled refill, per-VIN lock serialization, failure-preserves-cache, orphan prune at both layers), attribute slimming shape, and service behaviours. `ruff check` + `ruff format` clean.
