### PR TITLE
climate: consume the pytoyoda 5.2.0 V2 climate endpoints

### DIFF
--- a/custom_components/toyota/climate.py
+++ b/custom_components/toyota/climate.py
@@ -13,14 +13,14 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
-from homeassistant.helpers.event import async_call_later
 from pytoyoda.models.endpoints.climate import (
-    ACOperations,
-    ACParameters,
-    ClimateControlModel,
-    ClimateSettingsModel,
+    HeatingOptionsModel,
+    SeatOptionsModel,
+    V2RemoteClimateControlRequestModel,
 )
+from pytoyoda.models.endpoints.common import UnitValueModel
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -35,8 +35,14 @@ from .entity import ToyotaBaseEntity
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=120)
 
-# Debounce delay for API calls (in seconds)
-SETTINGS_DEBOUNCE_DELAY = 5.0
+# Command success code in the V2 climate-control response payload.
+CLIMATE_COMMAND_OK = "000000"
+
+# The /v1/vehicle/climate-settings payload no longer carries min/max/step; mirror
+# the MyToyota app's fixed 18-29 degree range with a 1-degree step.
+DEFAULT_MIN_TEMP = 18
+DEFAULT_MAX_TEMP = 29
+DEFAULT_TEMP_STEP = 1
 
 
 async def async_setup_entry(
@@ -63,6 +69,14 @@ async def async_setup_entry(
 def _vehicle_has_climate_capability(vehicle: Vehicle) -> bool:
     """Check if vehicle supports climate control."""
     try:
+        # Standard path (ICE / hybrid, e.g. Corolla): legacy feature flag.
+        if getattr(
+            getattr(vehicle._vehicle_info, "features", False),  # noqa : SLF001
+            "climate_start_engine",
+            False,
+        ):
+            return True
+        # PHEV / EV path: extended capabilities (added upstream in ea73031).
         caps = getattr(vehicle._vehicle_info, "extended_capabilities", False)  # noqa : SLF001
         for cap in [
             "climate_capable",
@@ -113,9 +127,11 @@ class ToyotaClimate(ToyotaBaseEntity, ClimateEntity):
         self._attr_current_temperature = None
         self._attr_climate_status = False
 
-        # Debouncing state - using HA's task cancellation
-        self._pending_settings_cancel = None
-        self._settings_changed = False
+        # User-set target-temp / defrost are applied on the next climate START
+        # (Tier A sends the full desired body). This flag marks them dirty so a
+        # coordinator poll can't overwrite them with the car's saved values before
+        # the start lands; it's cleared once a start is confirmed.
+        self._settings_dirty = False
 
         # Load settings from coordinator if available
         self._load_climate_settings_from_coordinator()
@@ -144,38 +160,94 @@ class ToyotaClimate(ToyotaBaseEntity, ClimateEntity):
             _LOGGER.exception("Error loading climate settings from coordinator")
 
     def _load_temperature_settings(self) -> None:
-        """Load temperature settings from climate_settings."""
+        """Load target temperature + unit from climate_settings."""
+        # Don't clobber a user-set target the user hasn't started yet.
+        if self._settings_dirty:
+            return
         climate_settings = self.vehicle.climate_settings
         target_temperature = climate_settings.temperature
         if target_temperature is not None and target_temperature.value is not None:
             self._attr_target_temperature = target_temperature.value
-        # `or <default>` guards against the attribute existing but being None
-        # (climate-settings HTTP 500). A None min/max_temp makes HA core's
-        # set_temperature validation do `float < None` -> TypeError; keep the
-        # __init__ defaults (18/29/1) instead.
-        self._attr_min_temp = getattr(climate_settings, "min_temp", None) or 18
-        self._attr_max_temp = getattr(climate_settings, "max_temp", None) or 29
-        self._attr_target_temperature_step = (
-            getattr(climate_settings, "temp_interval", None) or 1
-        )
+            # Honor the unit the car reports rather than assuming Celsius.
+            unit = (target_temperature.unit or "").upper()
+            self._attr_temperature_unit = (
+                UnitOfTemperature.FAHRENHEIT
+                if unit.startswith("F")
+                else UnitOfTemperature.CELSIUS
+            )
+        # The new climate-settings payload no longer carries min/max/step; use the
+        # app's fixed bounds (a None min/max would make HA core's set_temperature
+        # validation do `float < None` -> TypeError).
+        self._attr_min_temp = DEFAULT_MIN_TEMP
+        self._attr_max_temp = DEFAULT_MAX_TEMP
+        self._attr_target_temperature_step = DEFAULT_TEMP_STEP
 
     def _load_defrost_settings(self) -> None:
-        """Load defrost settings from climate_settings operations."""
-        climate_settings = self.vehicle.climate_settings
-        # API can return operations=None (e.g. climate-settings HTTP 500);
-        # `or []` guards against the attribute existing but being None.
-        operations = getattr(climate_settings, "operations", None) or []
-        for operation in filter(lambda o: o.category_name == "defrost", operations):
-            for param in operation.parameters:
-                if param.name == "frontDefrost":
-                    self._attr_front_defrost = param.enabled
-                elif param.name == "rearDefrost":
-                    self._attr_rear_defrost = param.enabled
+        """Load defrost/defogger state from climate_settings heating options."""
+        # Don't clobber a user-set preset the user hasn't started yet.
+        if self._settings_dirty:
+            return
+        # Migrated 2026-07: defrost state moved from the old acOperations list to
+        # the new heatingOptions map. heating_options can be None (climate-settings
+        # 403/500), so guard before reading.
+        heating = getattr(self.vehicle.climate_settings, "heating_options", None)
+        if heating is None:
+            return
+        if heating.front_defroster is not None:
+            self._attr_front_defrost = heating.front_defroster
+        if heating.rear_defogger is not None:
+            self._attr_rear_defrost = heating.rear_defogger
+
+    def _load_climate_status_from_coordinator(self) -> None:
+        """Reflect the car's live climate state (on/off + cabin temp) if available.
+
+        The coordinator fetches climate_status each cycle; reading it here keeps the
+        entity truthful even when climate is started/stopped from the Toyota app.
+        """
+        try:
+            climate_status = getattr(self.vehicle, "climate_status", None)
+            if climate_status is None:
+                return
+            is_on = climate_status.is_on
+            if is_on is not None:
+                self._attr_climate_status = is_on
+                self._attr_hvac_mode = HVACMode.HEAT_COOL if is_on else HVACMode.OFF
+            current = climate_status.current_temperature
+            self._attr_current_temperature = (
+                current.value if current is not None else None
+            )
+        except Exception:  # pylint: disable=W0718
+            _LOGGER.exception("Error loading climate status from coordinator")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Surface the new climate capabilities (read-only until the V2 PR).
+
+        Seat heaters are multi-level (off/low/medium/high); steering heater and the
+        defroster/defogger are on/off. These are not yet writable entities.
+        """
+        settings = getattr(self.vehicle, "climate_settings", None)
+        if settings is None:
+            return None
+        heating = settings.heating_options
+        seats = settings.seat_options
+        attrs: dict[str, Any] = {}
+        if heating is not None:
+            attrs["steering_heater"] = heating.steering_heater
+        if seats is not None:
+            attrs["seat_heater_driver"] = seats.driver_seat
+            attrs["seat_heater_passenger"] = seats.passenger_seat
+            attrs["seat_heater_rear_driver"] = seats.rear_driver_seat
+            attrs["seat_heater_rear_passenger"] = seats.rear_passenger_seat
+        if settings.duration is not None:
+            attrs["duration_minutes"] = int(settings.duration.total_seconds() // 60)
+        return attrs or None
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._load_climate_settings_from_coordinator()
+        self._load_climate_status_from_coordinator()
         super()._handle_coordinator_update()
 
     @property
@@ -224,37 +296,64 @@ class ToyotaClimate(ToyotaBaseEntity, ClimateEntity):
             return "rear_defrost"
         return "none"
 
-    def _create_climate_settings(self) -> ClimateSettingsModel:
-        """Create a ClimateSettingsModel with current defrost settings.
+    def _build_start_request(self) -> V2RemoteClimateControlRequestModel:
+        """Assemble the V2 ``start`` body from current entity + read state.
 
-        Returns:
-            ClimateSettingsModel configured with the specified settings
+        Front/rear defroster come from the entity's preset state; steering + per-seat
+        heaters are **echoed** from the current climate-settings read (never invented)
+        so a start doesn't change them.
         """
-        # Start with existing operations. climate_settings itself (not just
-        # .operations) can be None when the climate-settings endpoint 500'd, so
-        # getattr through both to avoid an AttributeError on the control path.
-        climate_settings = getattr(self.vehicle, "climate_settings", None)
-        ac_operations = (getattr(climate_settings, "operations", None) or []).copy()
+        settings = getattr(self.vehicle, "climate_settings", None)
+        read_heating = getattr(settings, "heating_options", None)
+        read_seats = getattr(settings, "seat_options", None)
 
-        # Find and replace the defrost operation
-        for i, operation in enumerate(ac_operations):
-            if operation.category_name == "defrost":
-                # Create new defrost operation with current values
-                ac_operations[i] = ACOperations(
-                    categoryName="defrost",
-                    acParameters=[
-                        ACParameters(enabled=self.front_defrost, name="frontDefrost"),
-                        ACParameters(enabled=self.rear_defrost, name="rearDefrost"),
-                    ],
-                )
-                break
+        def _wire(*, flag: bool | None) -> str | None:
+            return None if flag is None else ("on" if flag else "off")
 
-        return ClimateSettingsModel(
-            settingsOn=self.climate_settings_on,
-            temperature=self.target_temperature,
-            temperatureUnit="C",
-            acOperations=ac_operations,
+        heating = HeatingOptionsModel(
+            front_defroster=_wire(flag=self.front_defrost),
+            rear_defogger=_wire(flag=self.rear_defrost),
+            # Steering: echo the car's current value so a start doesn't change it.
+            # The read is ALREADY an "on"/"off" string, so pass it through raw — do
+            # NOT _wire() it (that turned "off" into "on", silently switching the
+            # wheel heater on with every start).
+            steering_heater=getattr(read_heating, "steering_heater", None),
         )
+        seats = None
+        if read_seats is not None:
+            seats = SeatOptionsModel(
+                driver_seat=read_seats.driver_seat,
+                passenger_seat=read_seats.passenger_seat,
+                rear_driver_seat=read_seats.rear_driver_seat,
+                rear_passenger_seat=read_seats.rear_passenger_seat,
+            )
+
+        unit = (
+            "F" if self._attr_temperature_unit == UnitOfTemperature.FAHRENHEIT else "C"
+        )
+        # Only persist defaults when we have a full read to echo — a null-options
+        # body with save_settings=True could clear the car's saved seat/steering.
+        save = read_seats is not None and read_heating is not None
+        return V2RemoteClimateControlRequestModel(
+            command="start",
+            temperature=UnitValueModel(unit=unit, value=self.target_temperature),
+            heating_options=heating,
+            seat_options=seats,
+            save_settings=save,
+        )
+
+    @staticmethod
+    def _command_ok(response: object) -> bool:
+        """Whether a V2 climate-control response reported command success."""
+        payload = getattr(response, "payload", None)
+        return payload is not None and payload.return_code == CLIMATE_COMMAND_OK
+
+    async def _poll_status(self) -> None:
+        """Wake + refetch climate_status and reflect it on the entity."""
+        if await self.vehicle.refresh_climate_status():
+            await self.vehicle.update(only=["climate_status"])
+            self._load_climate_status_from_coordinator()
+            self.async_write_ha_state()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
@@ -273,99 +372,23 @@ class ToyotaClimate(ToyotaBaseEntity, ClimateEntity):
                 self._attr_front_defrost = False
                 self._attr_rear_defrost = False
 
+            # Applied on the next start (V2 sends the full desired body); no
+            # standalone settings write in Tier A. Mark dirty so a coordinator poll
+            # doesn't revert it before the start.
+            self._settings_dirty = True
             self.async_write_ha_state()
-            self._debounce_send_climate_settings()
 
         except Exception:  # pylint: disable=W0718
             _LOGGER.exception("Error setting preset mode")
 
     async def async_update(self) -> None:
-        """Update climate settings from the car."""
+        """Poll the car for fresh climate status (when climate is on)."""
         if not self.climate_settings_on:
             return
-
         try:
-            if await self.vehicle.refresh_climate_status():
-                _LOGGER.debug("Climate status refreshed from car")
-                # vehicle.climate_status does not seem to work for some reason
-                response = await self.vehicle._api.get_climate_status(  # noqa: SLF001
-                    self.vehicle.vin
-                )
-                _LOGGER.debug("Climate status fetched %s", response)
-                climate_status = response.payload
-                if climate_status.status:
-                    _LOGGER.debug("Climate is on, sync current temperature")
-                    # car has started heating
-                    self._attr_climate_status = True
-                    self._attr_current_temperature = (
-                        climate_status.current_temperature.value
-                    )
-
-                elif self._attr_climate_status:
-                    _LOGGER.debug("Climate is now off")
-                    # turn off the climate device
-                    self._attr_hvac_mode = HVACMode.OFF
-                    self._attr_current_temperature = None
-                    # reset the climate status flag
-                    self._attr_climate_status = False
-
-                self.async_write_ha_state()
-
+            await self._poll_status()
         except Exception:  # pylint: disable=W0718
-            _LOGGER.exception("Error updating climate settings")
-
-    @callback
-    def _debounce_send_climate_settings(self) -> None:
-        """Debounce climate settings updates to avoid excessive API calls."""
-        # Cancel any pending scheduled call
-        if self._pending_settings_cancel is not None:
-            self._pending_settings_cancel()
-            self._pending_settings_cancel = None
-
-        # Mark that settings have changed
-        self._settings_changed = True
-
-        # Schedule the actual send after a delay using HA's event loop
-        self._pending_settings_cancel = async_call_later(
-            self.hass, SETTINGS_DEBOUNCE_DELAY, self._delayed_send_climate_settings
-        )
-
-    async def _delayed_send_climate_settings(self, _now: Any) -> None:  # noqa: ANN401
-        """Send settings after debounce delay.
-
-        Args:
-            _now: Current time (required by async_call_later, unused)
-        """
-        self._pending_settings_cancel = None
-        if self._settings_changed:
-            await self._send_climate_settings()
-            self._settings_changed = False
-
-    async def _send_climate_settings(self) -> bool:
-        """Send climate settings to car.
-
-        Returns:
-            True if settings were sent successfully, False on error
-        """
-        try:
-            climate_settings = self._create_climate_settings()
-            _LOGGER.debug("Sending climate settings to car: %s", climate_settings)
-            status = await self.vehicle._api.update_climate_settings(  # noqa: SLF001
-                self.vehicle.vin, climate_settings
-            )
-
-            _LOGGER.debug("API response status: %s", status)
-
-            # Check if the update was successful
-            if not status or (hasattr(status, "status") and status.status == 0):
-                _LOGGER.exception("Failed to send climate settings")
-                return False
-
-        except Exception:  # pylint: disable=W0718
-            _LOGGER.exception("Error sending climate settings")
-            return False
-
-        return True
+            _LOGGER.exception("Error updating climate status")
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
@@ -381,10 +404,11 @@ class ToyotaClimate(ToyotaBaseEntity, ClimateEntity):
             return
 
         try:
+            # Local desired state; applied on the next start (V2 sends the full body).
+            # Mark dirty so a coordinator poll doesn't revert it before the start.
             self._attr_target_temperature = temperature
+            self._settings_dirty = True
             self.async_write_ha_state()
-
-            self._debounce_send_climate_settings()
 
         except Exception:  # pylint: disable=W0718
             _LOGGER.exception("Error setting climate temperature")
@@ -397,74 +421,71 @@ class ToyotaClimate(ToyotaBaseEntity, ClimateEntity):
         """Turn off climate control."""
         await self._turn_off_climate()
 
+    async def _send_start(self) -> None:
+        """Send one V2 ``start`` with the current desired body; raise on rejection.
+
+        Keeps the request-build + success-check in one place.
+        """
+        response = await self.vehicle.set_climate(self._build_start_request())
+        ok = self._command_ok(response)
+        if not ok:
+            _LOGGER.debug("Climate start rejected: %s", response)
+            msg = (
+                "Toyota did not start the climate. Common causes: the car is "
+                "unlocked, a door/window/trunk is open, or a key is inside. "
+                "(Re-issuing a start while climate is already running is also "
+                "rejected.)"
+            )
+            raise HomeAssistantError(msg)
+        # The desired settings were accepted (and saved) — safe to resume seeding
+        # target-temp / defrost from the coordinator read again.
+        self._settings_dirty = False
+
     async def _turn_on_climate(self) -> None:
-        """Turn on the climate control."""
+        """Turn on climate via a single V2 ``start`` command."""
+        # Optimistically turn on; rolled back if the car rejects the start.
+        self._attr_hvac_mode = HVACMode.HEAT_COOL
+        self.async_write_ha_state()
+
+        _LOGGER.debug("Attempting to turn on climate for %s", self.vehicle.alias)
         try:
-            # optimistically turn on the climate device
-            self._attr_hvac_mode = HVACMode.HEAT_COOL
-            self.async_write_ha_state()
-
-            _LOGGER.debug("Attempting to turn on climate for %s", self.vehicle.alias)
-
-            # Cancel any pending debounced updates
-            if self._pending_settings_cancel is not None:
-                self._pending_settings_cancel()
-                self._pending_settings_cancel = None
-            self._settings_changed = False
-
-            # Send settings immediately when turning on
-            if await self._send_climate_settings():
-                # Now send the engine-start command to actually turn on climate
-                _LOGGER.debug("Sending engine-start command to %s", self.vehicle.alias)
-
-                status = await self.vehicle._api.send_climate_control_command(  # noqa: SLF001
-                    self.vehicle.vin, ClimateControlModel(command="engine-start")
-                )
-
-                # Check if the update was successful
-                if not status or (hasattr(status, "status") and status.status == 0):
-                    _LOGGER.debug("Failed to start engine: %s", status)
-                    # The official app sends a notification to the user
-                    # Should we send a notification to the user?
-                    # Potential reasons:
-                    # Car unreachable
-                    # Car is unlocked
-                    # One or more windows, doors or trunk open
-                    # Key detected inside the car
-                    # Climate was already started once for 20 minutes since
-                    # last engine ignition
-                    self._attr_hvac_mode = HVACMode.OFF
-                    self.async_write_ha_state()
-
-                else:
-                    _LOGGER.debug(
-                        "Climate control turned on for %s", self.vehicle.alias
-                    )
-
-        except Exception:  # pylint: disable=W0718
-            _LOGGER.exception("Error turning on climate")
-
-    async def _turn_off_climate(self) -> None:
-        """Turn off the climate control."""
-        try:
-            # optimistically turn off the climate device
+            await self._send_start()
+        except Exception as err:  # pylint: disable=W0718
+            # Roll back the optimistic "on" so the tile reflects reality.
             self._attr_hvac_mode = HVACMode.OFF
             self.async_write_ha_state()
+            if isinstance(err, HomeAssistantError):
+                raise
+            msg = f"Failed to turn on Toyota climate: {err}"
+            raise HomeAssistantError(msg) from err
 
-            _LOGGER.debug("Attempting to turn off climate for %s", self.vehicle.alias)
+        _LOGGER.debug("Climate control turned on for %s", self.vehicle.alias)
+        # Confirm the actual state (stopped -> starting/running) best-effort.
+        try:
+            await self._poll_status()
+        except Exception:  # noqa: BLE001  # best-effort poll; any failure is non-fatal
+            _LOGGER.debug("Post-start status poll failed (non-fatal)", exc_info=True)
 
-            # Send the engine-stop command to turn off climate
-            if await self.vehicle._api.send_climate_control_command(  # noqa: SLF001
-                self.vehicle.vin, ClimateControlModel(command="engine-stop")
-            ):
-                _LOGGER.debug("Climate control turned off for %s", self.vehicle.alias)
+    async def _turn_off_climate(self) -> None:
+        """Turn off climate via a single V2 ``stop`` command."""
+        # Optimistically turn off; the coordinator reconciles actual state on poll.
+        self._attr_hvac_mode = HVACMode.OFF
+        self.async_write_ha_state()
 
-        except Exception:  # pylint: disable=W0718
-            _LOGGER.exception("Error turning off climate")
+        _LOGGER.debug("Attempting to turn off climate for %s", self.vehicle.alias)
+        try:
+            response = await self.vehicle.set_climate(
+                V2RemoteClimateControlRequestModel(command="stop"),
+            )
+        except Exception as err:  # pylint: disable=W0718
+            # The stop may not have landed — revert to "on" rather than falsely off.
+            self._attr_hvac_mode = HVACMode.HEAT_COOL
+            self.async_write_ha_state()
+            msg = f"Failed to turn off Toyota climate: {err}"
+            raise HomeAssistantError(msg) from err
 
-    async def async_will_remove_from_hass(self) -> None:
-        """Clean up when entity is removed."""
-        # Cancel any pending scheduled calls
-        if self._pending_settings_cancel is not None:
-            self._pending_settings_cancel()
-            self._pending_settings_cancel = None
+        # A non-000000 on stop is usually benign ("already stopped"); don't error the
+        # tile — the next coordinator poll reconciles the real state via is_on.
+        if not self._command_ok(response):
+            _LOGGER.debug("Climate stop returned non-success: %s", response)
+        _LOGGER.debug("Climate control turned off for %s", self.vehicle.alias)

--- a/custom_components/toyota/manifest.json
+++ b/custom_components/toyota/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/pytoyoda/ha_toyota",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pytoyoda/ha_toyota/issues",
-  "requirements": ["pytoyoda>=5.1.0,<6.0", "arrow"],
+  "requirements": ["pytoyoda>=5.2.0,<6.0", "arrow"],
   "version": "v2.4.0"
 }


### PR DESCRIPTION
## What

Toyota migrated the remote-climate surface behind the scenes:
- **reads** moved to `/v1/vehicle/climate-*`
- the old **settings-PUT + control-POST** were unified into a single **`POST /v2/remote/climate-control`**

`pytoyoda` **5.2.0** ships this migration (pytoyoda/pytoyoda#267 → #268/#269/#270/#271): it removes `update_climate_settings`, reshapes `send_climate_control_command`, and adds a public `Vehicle.set_climate()` wrapper. As a result the **current climate entity can no longer actuate** against pytoyoda ≥5.2.0 — `async_set_preset_mode` / turn on/off call `vehicle._api.update_climate_settings(...)`, which no longer exists (`AttributeError`). Reads still work; **control is broken** until the consumer is migrated.

This PR reworks the climate entity onto the new surface.

## Changes

- **Actuate via the public `vehicle.set_climate()`** — no more `vehicle._api.*` reach-through.
- **Build the unified V2 `start` body** (`temperature` + `heating_options` + `seat_options`), echoing steering-wheel and per-seat heaters from the current climate read so a `start` never silently changes them.
- **Fixed temperature range** — `/v1/vehicle/climate-settings` no longer carries min/max/step, so mirror the MyToyota app's fixed **18–29 °C, 1° step**.
- **`_settings_dirty` guard** — a user-set target temp / defroster toggle was being clobbered by the coordinator settings-reload that lands between the UI change and the `start`. The entity now holds the desired settings until the `start` is accepted.
- **Surface command rejection** as `HomeAssistantError` (car unlocked / door open / key inside / already running) instead of optimistically faking success.

## Requires

`pytoyoda>=5.2.0` (manifest bumped).

## Supersedes

Supersedes #319 — the "surface command failures instead of faking success" behaviour is included here (start rejection now raises `HomeAssistantError`), and #319 targets the pre-migration `climate.py` that this PR replaces. I'll close #319 with a pointer to this PR.

## Testing

- `ruff check` (`select = ALL`) clean; syntax compiles.
- Every pytoyoda symbol / method / model-field verified against the released `v5.2.0` tag.
- Running live on a Corolla TS (LHD) via our deploy fork: start with target temp + defrost, stop, and rejection paths (start while unlocked → `HomeAssistantError`) all behave.

Fixes #318
Fixes #246
Fixes #296
