### PR TITLE
fix(config_flow): config entry title is a 1-tuple, not a string

### DIFF
--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -151,6 +151,34 @@ class VehicleData(TypedDict):
     is_cached: bool
 
 
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate a config entry to the current version.
+
+    1.1 -> 1.2: repair a non-string title. Entries created before the config
+    flow stopped building its title as a 1-tuple persist it as a JSON list
+    (``["Toyota - user@example.com"]``), which breaks every consumer that
+    reads a config entry title as text. Users cannot clear this themselves:
+    the ``config_entries/update`` websocket command validates ``title`` as
+    ``str``, so a client that echoes the stored value back is rejected.
+    """
+    if entry.version == 1 and entry.minor_version < 2:
+        title = entry.title
+
+        if not isinstance(title, str):
+            if isinstance(title, (list, tuple)) and title:
+                title = str(title[0])
+            else:
+                # No usable title to unwrap; rebuild the one the flow would
+                # have created from the entry's own data.
+                brand = str(entry.data.get(CONF_BRAND, "toyota")).capitalize()
+                title = f"{brand} - {entry.data.get(CONF_EMAIL, '')}"
+            _LOGGER.info("Repaired non-string config entry title: %s", title)
+
+        hass.config_entries.async_update_entry(entry, title=title, minor_version=2)
+
+    return True
+
+
 async def async_setup_entry(  # pylint: disable=too-many-statements # noqa: PLR0915, C901
     hass: HomeAssistant, entry: ConfigEntry
 ) -> bool:

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -34,6 +34,8 @@ from .const import (
     CONF_POLLING_INTERVAL_MINUTES,
     CONF_POST_COUNT_PER_STOP,
     CONF_RETAIN_ON_TRANSIENT_FAILURE,
+    CONFIG_ENTRY_MINOR_VERSION,
+    CONFIG_ENTRY_VERSION,
     DEFAULT_AUTO_DISABLED_STATUS_REFRESH,
     DEFAULT_ENABLE_STATUS_REFRESH,
     DEFAULT_FAILED_WAKE_THRESHOLD,
@@ -161,7 +163,10 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     the ``config_entries/update`` websocket command validates ``title`` as
     ``str``, so a client that echoes the stored value back is rejected.
     """
-    if entry.version == 1 and entry.minor_version < 2:
+    if (
+        entry.version == CONFIG_ENTRY_VERSION
+        and entry.minor_version < CONFIG_ENTRY_MINOR_VERSION
+    ):
         title = entry.title
 
         if not isinstance(title, str):
@@ -174,7 +179,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 title = f"{brand} - {entry.data.get(CONF_EMAIL, '')}"
             _LOGGER.info("Repaired non-string config entry title: %s", title)
 
-        hass.config_entries.async_update_entry(entry, title=title, minor_version=2)
+        hass.config_entries.async_update_entry(
+            entry, title=title, minor_version=CONFIG_ENTRY_MINOR_VERSION
+        )
 
     return True
 

--- a/custom_components/toyota/config_flow.py
+++ b/custom_components/toyota/config_flow.py
@@ -72,6 +72,8 @@ class ToyotaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pylint: dis
     """Handle a config flow for Toyota Connected Services."""
 
     VERSION = 1
+    # 1.2 repairs entries created with a 1-tuple title, see async_migrate_entry.
+    MINOR_VERSION = 2
 
     @staticmethod
     def async_get_options_flow(

--- a/custom_components/toyota/config_flow.py
+++ b/custom_components/toyota/config_flow.py
@@ -138,7 +138,7 @@ class ToyotaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pylint: dis
             else:
                 if not self._reauth_entry:
                     entry_title = (
-                        f"{BRAND_OPTIONS[self._brand]} - {user_input[CONF_EMAIL]}",
+                        f"{BRAND_OPTIONS[self._brand]} - {user_input[CONF_EMAIL]}"
                     )
                     return self.async_create_entry(
                         title=entry_title,

--- a/custom_components/toyota/config_flow.py
+++ b/custom_components/toyota/config_flow.py
@@ -30,6 +30,8 @@ from .const import (
     CONF_POLLING_INTERVAL_MINUTES,
     CONF_POST_COUNT_PER_STOP,
     CONF_RETAIN_ON_TRANSIENT_FAILURE,
+    CONFIG_ENTRY_MINOR_VERSION,
+    CONFIG_ENTRY_VERSION,
     DEFAULT_ENABLE_STATUS_REFRESH,
     DEFAULT_FAILED_WAKE_THRESHOLD,
     DEFAULT_IDLE_WAKE_HOURS,
@@ -71,9 +73,8 @@ def _writable_cwd(path: str) -> Generator[None]:
 class ToyotaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pylint: disable=W0223
     """Handle a config flow for Toyota Connected Services."""
 
-    VERSION = 1
-    # 1.2 repairs entries created with a 1-tuple title, see async_migrate_entry.
-    MINOR_VERSION = 2
+    VERSION = CONFIG_ENTRY_VERSION
+    MINOR_VERSION = CONFIG_ENTRY_MINOR_VERSION
 
     @staticmethod
     def async_get_options_flow(

--- a/custom_components/toyota/const.py
+++ b/custom_components/toyota/const.py
@@ -11,6 +11,12 @@ PLATFORMS = [
     Platform.CLIMATE,
 ]
 
+# CONFIG ENTRY SCHEMA
+# 1.2 repairs entries whose title was stored as a 1-tuple; the migration
+# lives in async_migrate_entry.
+CONFIG_ENTRY_VERSION = 1
+CONFIG_ENTRY_MINOR_VERSION = 2
+
 # INTEGRATION ATTRIBUTES
 DOMAIN = "toyota"
 NAME = "Toyota Connected Services"


### PR DESCRIPTION
A trailing comma inside the parentheses makes `entry_title` a single-element **tuple** rather than a string, so the config entry is created with a list title.

```python
entry_title = (
    f"{BRAND_OPTIONS[self._brand]} - {user_input[CONF_EMAIL]}",   # <- this comma
)
```

**Symptom.** The stored entry title comes out as `["Toyota - user@example.com"]` instead of `Toyota - user@example.com`. Visible on a live entry via the config-entries API/websocket, and it breaks anything that reads a config entry title as text.

**Fix.** Remove the comma. Kept the parentheses because the single-line form is 92 chars, over the 88 limit — so this is also what `ruff format` produces.

## Migration (added 08-01, after @maxmaxme's report)

Removing the comma only helps entries created from here on. Existing entries keep the list title permanently, so this now also bumps `MINOR_VERSION` to 2 and repairs them once via `async_migrate_entry`.

The original description suggested renaming the entry in the UI instead. That was bad advice: `config_entries/update` validates `title` as `str`, so any client that echoes the stored list back is rejected with `expected str for dictionary value @ data['title']` and the entry is left untouched — a user cannot reliably clear this themselves.

- **Downgrade-safe.** An entry at 1.2 loading on an older release takes core's `same_major_version` path and returns `True`; no migration handler is required there.
- **Never runs on new entries.** The flow stamps `MINOR_VERSION` at creation, so post-fix entries are already at 1.2.
- **Fallback.** When there is nothing to unwrap, the title is rebuilt from the entry's own `Brand` + `email` — the same string the flow would have produced.

## Scope / caveats

- Only the initial-setup path was ever affected; the reauth branch below it does not set a title.
- No behaviour change beyond the title type.
- Tests in `tests/test_init_migration.py`: list unwrap, string passthrough, rebuild fallback, and no-op when the entry is already at 1.2.

Found while auditing an installation whose entry title was showing up as a JSON list.
