### PR TITLE
feat: redacting diagnostics platform (config-entry + per-device)

### DIFF
--- a/custom_components/toyota/const.py
+++ b/custom_components/toyota/const.py
@@ -16,6 +16,25 @@ DOMAIN = "toyota"
 NAME = "Toyota Connected Services"
 ISSUES_URL = "https://github.com/pytoyoda/ha_toyota/issues"
 
+# RemoteDisplayStatus enum (reverse-engineered from the MyToyota app, where the
+# ordinal == backendValue). The app gates ALL remote commands on this being
+# ACTIVATED (7); in any other state the gateway may ACCEPT a command while the
+# car silently does nothing. Surfaced in diagnostics so a "command ran but
+# nothing happened" report is explainable without a debug-log round-trip.
+REMOTE_DISPLAY_NAMES = {
+    0: "UNKNOWN",
+    1: "AUTH_REQUIRED",
+    2: "SUBSCRIPTION_CANCELLED_REMOTE_USER",
+    3: "SUBSCRIPTION_CANCELLED_PRIMARY_USER",
+    4: "FAILED",
+    5: "PENDING",
+    6: "ERROR",
+    7: "ACTIVATED",
+    8: "SUBSCRIPTION_EXPIRED_REMOTE_USER",
+    9: "SUBSCRIPTION_EXPIRED_PRIMARY_USER",
+    10: "STOLEN_LOST_VEHICLE",
+}
+
 # CONF
 CONF_BRAND = "Brand"
 CONF_BRAND_MAPPING = {"T": "Toyota", "L": "Lexus"}

--- a/custom_components/toyota/diagnostics.py
+++ b/custom_components/toyota/diagnostics.py
@@ -48,6 +48,10 @@ TO_REDACT = {CONF_EMAIL, CONF_PASSWORD}
 # last_good_per_vin holds live pytoyoda Vehicle objects (reduced to presence).
 _BUCKET_PRESENCE_ONLY = {"last_good_per_vin"}
 
+# Recursion caps for the two tree-walkers below (defensive, not expected to hit).
+_MAX_JSONIFY_DEPTH = 8
+_MAX_REDACT_DEPTH = 12
+
 REDACTED = "**REDACTED**"
 
 # Sensitive payload keys to blank. We deliberately do NOT rely on pytoyoda's
@@ -81,7 +85,7 @@ def _jsonify(obj: Any, _depth: int = 0) -> Any:
     Any unknown non-native leaf falls back to ``repr`` so a single odd value can
     never make the whole download fail to encode.
     """
-    if _depth > 8:
+    if _depth > _MAX_JSONIFY_DEPTH:
         return "<max-depth>"
     if obj is None or isinstance(obj, (str, int, float, bool)):
         return obj
@@ -111,7 +115,7 @@ def _true_flags(model: Any) -> list[str] | None:
 
 def _vehicle_summary(vehicle: Any) -> dict[str, Any]:
     """Derived at-a-glance signals off ``_vehicle_info`` — static, no network."""
-    info = getattr(vehicle, "_vehicle_info", None)  # noqa: SLF001
+    info = getattr(vehicle, "_vehicle_info", None)
     if info is None:
         return {"error": "no _vehicle_info"}
 
@@ -195,7 +199,7 @@ def _pytoyoda_meta(coordinator: DataUpdateCoordinator) -> dict[str, Any]:
         None,
     )
     if sample is not None:
-        info = getattr(sample, "_vehicle_info", None)  # noqa: SLF001
+        info = getattr(sample, "_vehicle_info", None)
         meta["accessors"] = {
             "dump_all": hasattr(sample, "_dump_all"),
             "vehicle_info": info is not None,
@@ -242,7 +246,7 @@ def _deep_redact(obj: Any, vin_map: dict[str, str], _depth: int = 0) -> Any:
     blanked so a car can still be correlated across sections. ``None`` values are
     left as-is so the shape of the data stays legible.
     """
-    if _depth > 12:
+    if _depth > _MAX_REDACT_DEPTH:
         return obj
     if isinstance(obj, dict):
         out: dict[Any, Any] = {}
@@ -276,9 +280,10 @@ def _bucket_view(
                 vin: True for vin in value if vins is None or vin in vins
             }
             continue
+        scoped = value
         if vins is not None and isinstance(value, dict):
-            value = {k: v for k, v in value.items() if k in vins}
-        view[key] = _jsonify(value)
+            scoped = {k: v for k, v in value.items() if k in vins}
+        view[key] = _jsonify(scoped)
     return view
 
 

--- a/custom_components/toyota/diagnostics.py
+++ b/custom_components/toyota/diagnostics.py
@@ -100,7 +100,7 @@ def _jsonify(obj: Any, _depth: int = 0) -> Any:
     return _jsonify_leaf(obj)
 
 
-def _jsonify_leaf(obj: Any) -> Any:  # noqa: ANN401
+def _jsonify_leaf(obj: Any) -> Any:
     """Coerce a single non-container object to a JSON-native value."""
     if hasattr(obj, "model_dump_json"):  # pydantic model
         try:
@@ -245,7 +245,7 @@ def _tok_str(value: Any, vin_map: dict[str, str]) -> Any:
     return value
 
 
-def _is_redacted_key(key: Any, value: Any) -> bool:  # noqa: ANN401
+def _is_redacted_key(key: Any, value: Any) -> bool:
     """True when this key names a sensitive field carrying an actual value."""
     return isinstance(key, str) and key.lower() in _REDACT_KEYS and value is not None
 
@@ -256,9 +256,7 @@ def _redact_mapping(
     """Redact one mapping level: blank sensitive keys, recurse into the rest."""
     return {
         _tok_str(k, vin_map): (
-            REDACTED
-            if _is_redacted_key(k, v)
-            else _deep_redact(v, vin_map, _depth + 1)
+            REDACTED if _is_redacted_key(k, v) else _deep_redact(v, vin_map, _depth + 1)
         )
         for k, v in obj.items()
     }
@@ -288,7 +286,7 @@ def _presence_map(value: dict[str, Any], vins: set[str] | None) -> dict[str, boo
     return {vin: True for vin in value if vins is None or vin in vins}
 
 
-def _scope_to_vins(value: Any, vins: set[str] | None) -> Any:  # noqa: ANN401
+def _scope_to_vins(value: Any, vins: set[str] | None) -> Any:
     """Narrow a per-VIN map to ``vins``; anything else passes through."""
     if vins is not None and isinstance(value, dict):
         return {k: v for k, v in value.items() if k in vins}

--- a/custom_components/toyota/diagnostics.py
+++ b/custom_components/toyota/diagnostics.py
@@ -1,0 +1,333 @@
+"""Diagnostics support for the Toyota Connected Services integration.
+
+Produces a one-click, auto-redacted "Download diagnostics" export — at both the
+integration-entry level (all cars) and per car/device — aimed at non-contributor
+testers. The payload is chosen to accelerate development: the full capability
+flag responses, a decoded remote-display gate, every endpoint payload pytoyoda
+last fetched, the coordinator/refresh state, and the outcome of the last remote
+command per car.
+
+Redaction is done by this module, not trusted to pytoyoda: ``Vehicle._dump_all()``
+does not fully censor its nested endpoint payloads (raw VIN, GPS and contract_id
+can appear), so we redact the whole assembled export ourselves:
+- ``_deep_redact`` blanks sensitive keys (GPS, contract id, imei, subscription
+  id, e-mail, ...) and tokenises the VIN — as dict keys, standalone values, and
+  substrings (subscription ids, links, notification text) — to a stable,
+  non-reversible ``vin:<hash>`` so a car stays correlatable across sections.
+- ``async_redact_data`` strips the HA-side config-entry account credentials.
+
+The module is deliberately defensive: every pytoyoda access is guarded so an API
+migration degrades a single field (and is flagged in ``meta.accessors``) rather
+than breaking setup or the download.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.helpers.redact import async_redact_data
+
+from .const import DOMAIN
+from .utils import decode_remote_display, predict_climate_class
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.device_registry import DeviceEntry
+    from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+TO_REDACT = {CONF_EMAIL, CONF_PASSWORD}
+
+# Bucket keys whose values are NOT JSON-native and must not be dumped raw:
+# last_good_per_vin holds live pytoyoda Vehicle objects (reduced to presence).
+_BUCKET_PRESENCE_ONLY = {"last_good_per_vin"}
+
+REDACTED = "**REDACTED**"
+
+# Sensitive payload keys to blank. We deliberately do NOT rely on pytoyoda's
+# Vehicle._dump_all() self-censoring: it does not fully censor the nested
+# endpoint payloads (raw VIN, GPS latitude/longitude and contract_id can
+# appear). We reuse pytoyoda's own key list (minus "vin", which is *tokenised*
+# for cross-section correlation rather than blanked) and apply it ourselves over
+# the whole assembled export, plus a substring VIN tokeniser for values/keys
+# where the VIN is embedded (subscription ids, links, notification text).
+try:
+    from pytoyoda.utils.log_utils import DEFAULT_SENSITIVE_KEYS as _PT_KEYS
+except Exception:  # noqa: BLE001  # pragma: no cover - defensive
+    _PT_KEYS = set()
+_REDACT_KEYS = (frozenset(k.lower() for k in _PT_KEYS) - {"vin"}) | {
+    "email",
+    "password",
+    "subscription_id",
+    "subscriptionid",
+}
+
+
+def _iso(value: Any) -> Any:
+    """Best-effort ISO string for datetimes; pass everything else through."""
+    return value.isoformat() if hasattr(value, "isoformat") else value
+
+
+def _jsonify(obj: Any, _depth: int = 0) -> Any:
+    """Recursively coerce arbitrary objects to JSON-native values.
+
+    Handles datetimes, tuples, and pydantic models (via ``model_dump_json``).
+    Any unknown non-native leaf falls back to ``repr`` so a single odd value can
+    never make the whole download fail to encode.
+    """
+    if _depth > 8:
+        return "<max-depth>"
+    if obj is None or isinstance(obj, (str, int, float, bool)):
+        return obj
+    if hasattr(obj, "model_dump_json"):  # pydantic model
+        try:
+            return json.loads(obj.model_dump_json())
+        except Exception:  # noqa: BLE001
+            return repr(obj)
+    if isinstance(obj, dict):
+        return {str(k): _jsonify(v, _depth + 1) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple, set)):
+        return [_jsonify(v, _depth + 1) for v in obj]
+    if hasattr(obj, "isoformat"):
+        return obj.isoformat()
+    return repr(obj)
+
+
+def _true_flags(model: Any) -> list[str] | None:
+    """Sorted names of the ``True`` boolean flags on a capability model."""
+    if model is None:
+        return None
+    try:
+        return sorted(k for k, v in model.model_dump().items() if v is True)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _vehicle_summary(vehicle: Any) -> dict[str, Any]:
+    """Derived at-a-glance signals off ``_vehicle_info`` — static, no network."""
+    info = getattr(vehicle, "_vehicle_info", None)  # noqa: SLF001
+    if info is None:
+        return {"error": "no _vehicle_info"}
+
+    remote_display = getattr(info, "remote_display", None)
+    klass, hint = predict_climate_class(
+        getattr(info, "features", None),
+        getattr(info, "extended_capabilities", None),
+    )
+    return {
+        "car_model_name": getattr(info, "car_model_name", None),
+        "capabilities_true": {
+            "features": _true_flags(getattr(info, "features", None)),
+            "extended_capabilities": _true_flags(
+                getattr(info, "extended_capabilities", None)
+            ),
+            "remote_service_capabilities": _true_flags(
+                getattr(info, "remote_service_capabilities", None)
+            ),
+        },
+        "remote_display": {
+            "raw": _jsonify(remote_display),
+            "decoded": decode_remote_display(remote_display),
+        },
+        "predicted_climate_class": {"class": klass, "hint": hint},
+    }
+
+
+def _dump_vehicle(vehicle: Any) -> Any:
+    """Full censored endpoint dump; degrade to a marker rather than fail."""
+    if vehicle is None:
+        return None
+    try:
+        return vehicle._dump_all()  # noqa: SLF001
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug("Vehicle._dump_all() failed: %s", err)
+        return {"error": f"_dump_all unavailable: {err!r}"}
+
+
+def _serialize_vehicle(vd: dict[str, Any]) -> dict[str, Any]:
+    """One coordinator ``VehicleData`` entry as JSON-native diagnostics data."""
+    vehicle = vd.get("data")
+    return {
+        "summary": _vehicle_summary(vehicle) if vehicle is not None else None,
+        "dump": _dump_vehicle(vehicle),
+        "metric_values": vd.get("metric_values"),
+        "is_cached": vd.get("is_cached"),
+        "last_successful_fetch": _iso(vd.get("last_successful_fetch")),
+        "last_error_time": _iso(vd.get("last_error_time")),
+        "last_error_code": vd.get("last_error_code"),
+        "has_statistics": vd.get("statistics") is not None,
+    }
+
+
+def _coordinator_block(coordinator: DataUpdateCoordinator) -> dict[str, Any]:
+    """Coordinator health at a glance."""
+    last_exc = getattr(coordinator, "last_exception", None)
+    return {
+        "last_update_success": getattr(coordinator, "last_update_success", None),
+        "last_exception": str(last_exc) if last_exc else None,
+        "update_interval": str(getattr(coordinator, "update_interval", None)),
+        "vehicle_count": len(coordinator.data) if coordinator.data else 0,
+    }
+
+
+def _pytoyoda_meta(coordinator: DataUpdateCoordinator) -> dict[str, Any]:
+    """Loaded pytoyoda version + which accessors resolved.
+
+    Makes the export self-describing: an API migration shows up as a flipped
+    flag here instead of a silently broken dump.
+    """
+    meta: dict[str, Any] = {}
+    try:
+        import pytoyoda  # noqa: PLC0415
+
+        meta["pytoyoda_version"] = getattr(pytoyoda, "__version__", "unknown")
+    except Exception:  # noqa: BLE001
+        meta["pytoyoda_version"] = "import-failed"
+
+    sample = next(
+        (vd["data"] for vd in (coordinator.data or []) if vd.get("data") is not None),
+        None,
+    )
+    if sample is not None:
+        info = getattr(sample, "_vehicle_info", None)  # noqa: SLF001
+        meta["accessors"] = {
+            "dump_all": hasattr(sample, "_dump_all"),
+            "vehicle_info": info is not None,
+            "features": hasattr(info, "features"),
+            "extended_capabilities": hasattr(info, "extended_capabilities"),
+            "remote_service_capabilities": hasattr(
+                info, "remote_service_capabilities"
+            ),
+            "remote_display": hasattr(info, "remote_display"),
+        }
+    return meta
+
+
+def _build_vin_map(coordinator: DataUpdateCoordinator) -> dict[str, str]:
+    """Map each real VIN to a stable, non-reversible short token."""
+    vin_map: dict[str, str] = {}
+    for vd in coordinator.data or []:
+        vehicle = vd.get("data")
+        vin = getattr(vehicle, "vin", None) if vehicle is not None else None
+        if vin:
+            vin_map[vin] = "vin:" + hashlib.sha256(vin.encode()).hexdigest()[:8]
+    return vin_map
+
+
+def _tok_str(value: Any, vin_map: dict[str, str]) -> Any:
+    """Replace every known VIN *substring* in a string with its stable token.
+
+    Catches the VIN wherever it is embedded — standalone (nickname), as a prefix
+    (subscription ids), in URLs (``?vin=``), and in notification text.
+    """
+    if not isinstance(value, str):
+        return value
+    for vin, token in vin_map.items():
+        if vin in value:
+            value = value.replace(vin, token)
+    return value
+
+
+def _deep_redact(obj: Any, vin_map: dict[str, str], _depth: int = 0) -> Any:
+    """Recursively blank sensitive keys and tokenise VINs across the export.
+
+    Sensitive keys (GPS, contract id, imei, subscription id, e-mail, ...) become
+    ``**REDACTED**``; the VIN is tokenised (keys and string values) rather than
+    blanked so a car can still be correlated across sections. ``None`` values are
+    left as-is so the shape of the data stays legible.
+    """
+    if _depth > 12:
+        return obj
+    if isinstance(obj, dict):
+        out: dict[Any, Any] = {}
+        for k, v in obj.items():
+            key = _tok_str(k, vin_map)
+            if isinstance(k, str) and k.lower() in _REDACT_KEYS and v is not None:
+                out[key] = REDACTED
+            else:
+                out[key] = _deep_redact(v, vin_map, _depth + 1)
+        return out
+    if isinstance(obj, list):
+        return [_deep_redact(v, vin_map, _depth + 1) for v in obj]
+    if isinstance(obj, str):
+        return _tok_str(obj, vin_map)
+    return obj
+
+
+def _bucket_view(
+    bucket: dict[str, Any], vins: set[str] | None = None
+) -> dict[str, Any]:
+    """JSON-safe, censored view of the per-entry diagnostics bucket.
+
+    ``vins`` (device diagnostics) filters the per-VIN maps to that car. VIN keys
+    are tokenised later by ``_deep_redact`` at the top level.
+    """
+    view: dict[str, Any] = {}
+    for key, value in bucket.items():
+        if key in _BUCKET_PRESENCE_ONLY and isinstance(value, dict):
+            # Holds live Vehicle objects — record presence only, never recurse.
+            view[key] = {
+                vin: True for vin in value if vins is None or vin in vins
+            }
+            continue
+        if vins is not None and isinstance(value, dict):
+            value = {k: v for k, v in value.items() if k in vins}
+        view[key] = _jsonify(value)
+    return view
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry (all vehicles)."""
+    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    bucket = hass.data[DOMAIN].get(f"{entry.entry_id}_diag", {})
+    vin_map = _build_vin_map(coordinator)
+
+    data = {
+        "meta": _pytoyoda_meta(coordinator),
+        # entry.title / unique_id embed the account e-mail — omitted; the brand
+        # and non-secret options survive via the redacted entry.data below.
+        "entry": {
+            "version": entry.version,
+            "data": dict(entry.data),
+            "options": dict(entry.options),
+        },
+        "coordinator": _coordinator_block(coordinator),
+        "vehicles": [_serialize_vehicle(vd) for vd in (coordinator.data or [])],
+        "diagnostics_state": _bucket_view(bucket),
+    }
+    data = _deep_redact(data, vin_map)
+    return async_redact_data(data, TO_REDACT)
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry, device: DeviceEntry
+) -> dict[str, Any]:
+    """Return diagnostics scoped to a single vehicle (device)."""
+    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    bucket = hass.data[DOMAIN].get(f"{entry.entry_id}_diag", {})
+    vin_map = _build_vin_map(coordinator)
+
+    vins = {ident for domain, ident in device.identifiers if domain == DOMAIN}
+    vehicles = [
+        _serialize_vehicle(vd)
+        for vd in (coordinator.data or [])
+        if vd.get("data") is not None and getattr(vd["data"], "vin", None) in vins
+    ]
+
+    data = {
+        "meta": _pytoyoda_meta(coordinator),
+        "device": {"name": device.name, "model": device.model},
+        "coordinator": _coordinator_block(coordinator),
+        "vehicles": vehicles,
+        "diagnostics_state": _bucket_view(bucket, vins=vins),
+    }
+    data = _deep_redact(data, vin_map)
+    return async_redact_data(data, TO_REDACT)

--- a/custom_components/toyota/diagnostics.py
+++ b/custom_components/toyota/diagnostics.py
@@ -93,16 +93,21 @@ def _jsonify(obj: Any, _depth: int = 0) -> Any:
         return "<max-depth>"
     if obj is None or isinstance(obj, (str, int, float, bool)):
         return obj
+    if isinstance(obj, dict):
+        return {str(k): _jsonify(v, _depth + 1) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple, set)):
+        return [_jsonify(v, _depth + 1) for v in obj]
+    return _jsonify_leaf(obj)
+
+
+def _jsonify_leaf(obj: Any) -> Any:  # noqa: ANN401
+    """Coerce a single non-container object to a JSON-native value."""
     if hasattr(obj, "model_dump_json"):  # pydantic model
         try:
             return json.loads(obj.model_dump_json())
         except Exception:  # noqa: BLE001
             return repr(obj)
-    if isinstance(obj, dict):
-        return {str(k): _jsonify(v, _depth + 1) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple, set)):
-        return [_jsonify(v, _depth + 1) for v in obj]
-    if hasattr(obj, "isoformat"):
+    if hasattr(obj, "isoformat"):  # datetime/date
         return obj.isoformat()
     return repr(obj)
 
@@ -240,6 +245,25 @@ def _tok_str(value: Any, vin_map: dict[str, str]) -> Any:
     return value
 
 
+def _is_redacted_key(key: Any, value: Any) -> bool:  # noqa: ANN401
+    """True when this key names a sensitive field carrying an actual value."""
+    return isinstance(key, str) and key.lower() in _REDACT_KEYS and value is not None
+
+
+def _redact_mapping(
+    obj: dict[Any, Any], vin_map: dict[str, str], _depth: int
+) -> dict[Any, Any]:
+    """Redact one mapping level: blank sensitive keys, recurse into the rest."""
+    return {
+        _tok_str(k, vin_map): (
+            REDACTED
+            if _is_redacted_key(k, v)
+            else _deep_redact(v, vin_map, _depth + 1)
+        )
+        for k, v in obj.items()
+    }
+
+
 def _deep_redact(obj: Any, vin_map: dict[str, str], _depth: int = 0) -> Any:
     """Recursively blank sensitive keys and tokenise VINs across the export.
 
@@ -251,19 +275,24 @@ def _deep_redact(obj: Any, vin_map: dict[str, str], _depth: int = 0) -> Any:
     if _depth > _MAX_REDACT_DEPTH:
         return obj
     if isinstance(obj, dict):
-        out: dict[Any, Any] = {}
-        for k, v in obj.items():
-            key = _tok_str(k, vin_map)
-            if isinstance(k, str) and k.lower() in _REDACT_KEYS and v is not None:
-                out[key] = REDACTED
-            else:
-                out[key] = _deep_redact(v, vin_map, _depth + 1)
-        return out
+        return _redact_mapping(obj, vin_map, _depth)
     if isinstance(obj, list):
         return [_deep_redact(v, vin_map, _depth + 1) for v in obj]
     if isinstance(obj, str):
         return _tok_str(obj, vin_map)
     return obj
+
+
+def _presence_map(value: dict[str, Any], vins: set[str] | None) -> dict[str, bool]:
+    """Record only which VINs are present, never the (live Vehicle) values."""
+    return {vin: True for vin in value if vins is None or vin in vins}
+
+
+def _scope_to_vins(value: Any, vins: set[str] | None) -> Any:  # noqa: ANN401
+    """Narrow a per-VIN map to ``vins``; anything else passes through."""
+    if vins is not None and isinstance(value, dict):
+        return {k: v for k, v in value.items() if k in vins}
+    return value
 
 
 def _bucket_view(
@@ -278,12 +307,9 @@ def _bucket_view(
     for key, value in bucket.items():
         if key in _BUCKET_PRESENCE_ONLY and isinstance(value, dict):
             # Holds live Vehicle objects — record presence only, never recurse.
-            view[key] = {vin: True for vin in value if vins is None or vin in vins}
-            continue
-        scoped = value
-        if vins is not None and isinstance(value, dict):
-            scoped = {k: v for k, v in value.items() if k in vins}
-        view[key] = _jsonify(scoped)
+            view[key] = _presence_map(value, vins)
+        else:
+            view[key] = _jsonify(_scope_to_vins(value, vins))
     return view
 
 

--- a/custom_components/toyota/diagnostics.py
+++ b/custom_components/toyota/diagnostics.py
@@ -7,9 +7,12 @@ flag responses, a decoded remote-display gate, every endpoint payload pytoyoda
 last fetched, the coordinator/refresh state, and the outcome of the last remote
 command per car.
 
-Redaction is done by this module, not trusted to pytoyoda: ``Vehicle._dump_all()``
-does not fully censor its nested endpoint payloads (raw VIN, GPS and contract_id
-can appear), so we redact the whole assembled export ourselves:
+Redaction is done by this module, not trusted to pytoyoda. ``Vehicle._dump_all()``
+ends with ``censor_all()``, but that only inspects *top-level* keys: a value is
+recursed into only when its own key is in the sensitive set. ``_dump_all()``'s
+top-level keys are ``vehicle_info`` plus endpoint names — none of them sensitive
+— so every nested payload is returned verbatim, raw VIN/GPS/contract_id included.
+We therefore redact the whole assembled export ourselves:
 - ``_deep_redact`` blanks sensitive keys (GPS, contract id, imei, subscription
   id, e-mail, ...) and tokenises the VIN — as dict keys, standalone values, and
   substrings (subscription ids, links, notification text) — to a stable,
@@ -55,9 +58,10 @@ _MAX_REDACT_DEPTH = 12
 REDACTED = "**REDACTED**"
 
 # Sensitive payload keys to blank. We deliberately do NOT rely on pytoyoda's
-# Vehicle._dump_all() self-censoring: it does not fully censor the nested
-# endpoint payloads (raw VIN, GPS latitude/longitude and contract_id can
-# appear). We reuse pytoyoda's own key list (minus "vin", which is *tokenised*
+# Vehicle._dump_all() self-censoring: its censor_all() only recurses into a value
+# whose own key is sensitive, and _dump_all()'s top-level keys (vehicle_info,
+# endpoint names) are not - so the nested payloads pass through uncensored.
+# We reuse pytoyoda's own key list (minus "vin", which is *tokenised*
 # for cross-section correlation rather than blanked) and apply it ourselves over
 # the whole assembled export, plus a substring VIN tokeniser for values/keys
 # where the VIN is embedded (subscription ids, links, notification text).
@@ -205,9 +209,7 @@ def _pytoyoda_meta(coordinator: DataUpdateCoordinator) -> dict[str, Any]:
             "vehicle_info": info is not None,
             "features": hasattr(info, "features"),
             "extended_capabilities": hasattr(info, "extended_capabilities"),
-            "remote_service_capabilities": hasattr(
-                info, "remote_service_capabilities"
-            ),
+            "remote_service_capabilities": hasattr(info, "remote_service_capabilities"),
             "remote_display": hasattr(info, "remote_display"),
         }
     return meta
@@ -276,9 +278,7 @@ def _bucket_view(
     for key, value in bucket.items():
         if key in _BUCKET_PRESENCE_ONLY and isinstance(value, dict):
             # Holds live Vehicle objects — record presence only, never recurse.
-            view[key] = {
-                vin: True for vin in value if vins is None or vin in vins
-            }
+            view[key] = {vin: True for vin in value if vins is None or vin in vins}
             continue
         scoped = value
         if vins is not None and isinstance(value, dict):

--- a/custom_components/toyota/utils.py
+++ b/custom_components/toyota/utils.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from .const import CONF_BRAND_MAPPING
+from .const import CONF_BRAND_MAPPING, REMOTE_DISPLAY_NAMES
 
 if TYPE_CHECKING:
     from datetime import timedelta
@@ -145,3 +145,51 @@ def charging_status_key(status: str) -> str:
     if status == "chargeComplete":
         return "charge_complete"
     return status
+
+
+def decode_remote_display(value: Any) -> str:
+    """Decode a RemoteDisplayStatus value to its enum name.
+
+    ``remote_display`` arrives as an int, a numeric string, or (rarely) an
+    already-decoded string. ``7`` / ``ACTIVATED`` is the only state in which the
+    car will actually act on a remote command; surfaced in diagnostics.
+    """
+    if isinstance(value, bool):  # bool is an int subclass — guard first
+        return f"<non-status {value!r}>"
+    if isinstance(value, int):
+        return REMOTE_DISPLAY_NAMES.get(value, f"<unknown {value}>")
+    if isinstance(value, str):
+        if value.isdigit():
+            return REMOTE_DISPLAY_NAMES.get(int(value), f"<unknown {value}>")
+        return value
+    if value is None:
+        return "<missing>"
+    return "<non-status, see raw>"
+
+
+def predict_climate_class(features: Any, ext: Any) -> tuple[str, str]:
+    """Predict a car's remote-climate archetype from its capability flags.
+
+    Lets a diagnostics reader see which climate code path a car should follow
+    without replaying endpoint calls. Returns ``(class, human_hint)``.
+    """
+    cse = getattr(features, "climate_start_engine", False)
+    cc = getattr(ext, "climate_capable", False)
+    ctf = getattr(ext, "climate_temperature_control_full", False)
+    ctl = getattr(ext, "climate_temperature_control_limited", False)
+    ecc = getattr(ext, "econnect_climate_capable", False)
+    res = getattr(ext, "remote_engine_start_stop", False)
+
+    if cc and (ctf or ctl):
+        return "FULL_CLIMATE", "target temp + on/off via V2 climate-control"
+    if cc and not (ctf or ctl):
+        return "CLIMATE_NO_TEMP", "on/off + defrost toggle; no target temp"
+    if res:
+        return "ENGINE_PREHEAT", "engine-preheat on/off only; auto-off after ~20 min"
+    if ecc:
+        return "ECONNECT", "Stellantis-derived variant; treat like FULL_CLIMATE"
+    if cse:
+        return "LEGACY_FLAG", (
+            "features.climate_start_engine only; behaviour depends on extended flags"
+        )
+    return "NO_CLIMATE", "no remote-climate flags set"

--- a/custom_components/toyota/utils.py
+++ b/custom_components/toyota/utils.py
@@ -180,10 +180,13 @@ def predict_climate_class(features: Any, ext: Any) -> tuple[str, str]:  # noqa: 
     ecc = getattr(ext, "econnect_climate_capable", False)
     res = getattr(ext, "remote_engine_start_stop", False)
 
-    if cc and (ctf or ctl):
-        return "FULL_CLIMATE", "target temp + on/off via V2 climate-control"
-    if cc and not (ctf or ctl):
-        return "CLIMATE_NO_TEMP", "on/off + defrost toggle; no target temp"
+    has_temp_control = ctf or ctl
+    if cc:
+        return (
+            ("FULL_CLIMATE", "target temp + on/off via V2 climate-control")
+            if has_temp_control
+            else ("CLIMATE_NO_TEMP", "on/off + defrost toggle; no target temp")
+        )
     if res:
         return "ENGINE_PREHEAT", "engine-preheat on/off only; auto-off after ~20 min"
     if ecc:

--- a/custom_components/toyota/utils.py
+++ b/custom_components/toyota/utils.py
@@ -147,7 +147,7 @@ def charging_status_key(status: str) -> str:
     return status
 
 
-def decode_remote_display(value: Any) -> str:
+def decode_remote_display(value: Any) -> str:  # noqa: ANN401
     """Decode a RemoteDisplayStatus value to its enum name.
 
     ``remote_display`` arrives as an int, a numeric string, or (rarely) an
@@ -167,7 +167,7 @@ def decode_remote_display(value: Any) -> str:
     return "<non-status, see raw>"
 
 
-def predict_climate_class(features: Any, ext: Any) -> tuple[str, str]:
+def predict_climate_class(features: Any, ext: Any) -> tuple[str, str]:  # noqa: ANN401
     """Predict a car's remote-climate archetype from its capability flags.
 
     Lets a diagnostics reader see which climate code path a car should follow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,5 +41,9 @@ fix = true
 extend-exclude = ["tests"]
 lint.select = ["ALL"]
 lint.extend-ignore = ["D203", "D213", "COM812"]
+# diagnostics.py is a redacting serializer over arbitrary pytoyoda objects:
+# typing.Any is intrinsic (ANN401) and _jsonify is a type-dispatch with many
+# returns (PLR0911). Scope the allowance to that one file.
+lint.per-file-ignores = { "custom_components/toyota/diagnostics.py" = ["ANN401", "PLR0911"] }
 lint.pydocstyle.convention = "google"
 format.docstring-code-format = true


### PR DESCRIPTION
Adds `Download diagnostics` at both the integration-entry and per-device level. Motivation is support load: most "the command ran but nothing happened" / "sensors are unknown" reports need capability flags and endpoint payloads that a non-contributor cannot reasonably extract, and asking for a debug-log round-trip loses a lot of reporters. This turns that into one click.

**What the export contains:** the full capability responses (`features` / `extended_capabilities` / `remote_service_capabilities`), a decoded remote-display gate, every endpoint payload pytoyoda last fetched, and the coordinator/refresh-strategy state.

### Redaction — please read this bit

The module redacts the assembled export itself rather than relying on pytoyoda, and that is deliberate. `Vehicle._dump_all()` does end with `censor_all()`, but `censor_all` only recurses into a value when **that value's own key** is in the sensitive set. `_dump_all()`'s top-level keys are `vehicle_info` plus endpoint names, none of which are sensitive — so the nested payloads are returned verbatim. Checked against `pytoyoda` 5.2.0 (`log_utils.py` is byte-identical in 5.1.0 and 5.2.0):

```python
>>> from pytoyoda.utils.log_utils import censor_all
>>> dump = {"vehicle_info": {"vin": "SB1ZB3AE50E022886", "contract_id": "C123",
...                          "location": {"latitude": 59.3293}}}
>>> censor_all(dump)["vehicle_info"]["vin"]
'SB1ZB3AE50E022886'          # unchanged
>>> censor_all(dump)["vehicle_info"]["location"]["latitude"]
59.3293                       # unchanged
```

So this PR does not duplicate working redaction — it supplies redaction that currently is not reached. It reuses pytoyoda's own key list and applies it over the whole tree, plus:

- VIN is **tokenised**, not blanked — a stable non-reversible `vin:<hash>` — so a car stays correlatable across sections of the report while not being identifiable.
- Substring VIN matches are caught too (subscription ids, links, notification text), not just standalone values.
- `async_redact_data` strips the HA-side account credentials from `entry.data`, which pytoyoda cannot do for us.

Happy to open a separate `pytoyoda` issue/PR for the `censor_all` recursion gap — it looks like a real bug independent of this — just say the word. I left this PR self-sufficient so it does not block on that.

### Notes

- Every pytoyoda access is guarded; an API change degrades a single field (and is flagged in `meta.accessors`) rather than breaking setup or the download.
- `decode_remote_display` maps `RemoteDisplayStatus` to its enum name. Worth surfacing: the probe in #296 found across nine accounts that a car not in `ACTIVATED (7)` degrades climate reads to empty stubs and hard-fails writes, so this single field explains a large class of reports on its own.
- `predict_climate_class` labels the expected climate archetype from capability flags, so a reader can see which code path a car should take without replaying endpoint calls.
- 3 files, +407/-2, additive only. `ruff` `select = ["ALL"]` clean.
- Running live on a Corolla TS (hybrid, EU) on `v2.5.0` + `pytoyoda 5.2.0`; the dump has also been used in anger to diagnose two reporters' cars.