### PR TITLE
fix(binary_sensor): trunk sensors are gated on the hood's capability flag

### DIFF
--- a/custom_components/toyota/binary_sensor.py
+++ b/custom_components/toyota/binary_sensor.py
@@ -487,22 +487,23 @@ async def async_setup_entry(
                 ),
                 REAR_PASSENGER_DOOR_WINDOW_STATUS_ENTITY_DESCRIPTION,
             ),
-            # TODO(CM000n): Find correct matching capabilities in _vehicle_info # noqa : TD003, FIX002, E501
+            # Deliberately not gated on a capability flag: Toyota publishes
+            # no trunk *status* flag. The nearest candidates
+            # (extended_capabilities.trunk_lock_unlock_capable /
+            # .power_tailgate_capable, remote_service_capabilities.
+            # trunk_capable) all describe remote *commands*, not status
+            # reporting. Gating these on bonnet_status, the hood's flag, was
+            # wrong in both directions: it created trunk entities on cars
+            # that never report a trunk, and hid them on cars that do. A
+            # trunk that never reports now reads as unknown, the same
+            # posture as vehicle health below. Resolves the capability-
+            # matching question left open here, and ha_toyota#87.
             (
-                getattr(
-                    getattr(vehicle._vehicle_info, "extended_capabilities", False),  # noqa : SLF001
-                    "bonnet_status",
-                    False,
-                ),
+                True,
                 TRUNK_DOOR_LOCK_ENTITY_DESCRIPTION,
             ),
-            # TODO(CM000n): Find correct matching capabilities in _vehicle_info # noqa : TD003, FIX002, E501
             (
-                getattr(
-                    getattr(vehicle._vehicle_info, "extended_capabilities", False),  # noqa : SLF001
-                    "bonnet_status",
-                    False,
-                ),
+                True,
                 TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION,
             ),
             # Deliberately not gated on extended_capabilities

--- a/tests/test_binary_sensor_trunk.py
+++ b/tests/test_binary_sensor_trunk.py
@@ -1,0 +1,101 @@
+"""Tests for the trunk binary sensors (ha_toyota#87 capability gating).
+
+The trunk lock/open sensors used to be gated on ``bonnet_status`` -- the
+*hood's* capability flag -- so they appeared on cars that never report a
+trunk and were hidden on cars that do. They are now created unconditionally,
+because Toyota publishes no trunk *status* capability flag at all.
+
+That makes their null path load-bearing: on a car with no trunk telemetry
+these two entities now always exist, so they must read "unknown" rather than
+a false "open"/"unlocked". The payload shapes below are taken from the
+``lock_status`` JSON in ha_toyota#87.
+"""
+
+from __future__ import annotations
+
+from custom_components.toyota.binary_sensor import (
+    TRUNK_DOOR_LOCK_ENTITY_DESCRIPTION,
+    TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION,
+)
+
+
+class _FakeVehicle:
+    """Minimal vehicle stub; lock_status is set per fixture."""
+
+    lock_status = None
+
+
+class _FakeTrunk:
+    def __init__(self, closed: bool | None, locked: bool | None) -> None:
+        self.closed = closed
+        self.locked = locked
+
+
+class _FakeDoors:
+    def __init__(self, trunk: _FakeTrunk | None) -> None:
+        self.trunk = trunk
+
+
+class _FakeLockStatus:
+    def __init__(self, doors: _FakeDoors | None) -> None:
+        self.doors = doors
+
+
+def _vehicle(lock_status: _FakeLockStatus | None) -> _FakeVehicle:
+    vehicle = _FakeVehicle()
+    vehicle.lock_status = lock_status
+    return vehicle
+
+
+def test_trunk_reads_unknown_on_cold_cache():
+    """vehicle.lock_status is None before the first successful fetch."""
+    vehicle = _vehicle(None)
+    assert TRUNK_DOOR_LOCK_ENTITY_DESCRIPTION.value_fn(vehicle) is None
+    assert TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION.value_fn(vehicle) is None
+
+
+def test_trunk_reads_unknown_when_doors_absent():
+    """A status payload with no doors object at all."""
+    vehicle = _vehicle(_FakeLockStatus(doors=None))
+    assert TRUNK_DOOR_LOCK_ENTITY_DESCRIPTION.value_fn(vehicle) is None
+    assert TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION.value_fn(vehicle) is None
+
+
+def test_trunk_reads_unknown_when_car_has_no_trunk_entry():
+    """Doors reported, but this car never reports a trunk."""
+    vehicle = _vehicle(_FakeLockStatus(doors=_FakeDoors(trunk=None)))
+    assert TRUNK_DOOR_LOCK_ENTITY_DESCRIPTION.value_fn(vehicle) is None
+    assert TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION.value_fn(vehicle) is None
+
+
+def test_trunk_reads_unknown_on_null_fields():
+    """The ha_toyota#87 shape: trunk present, both fields null."""
+    vehicle = _vehicle(
+        _FakeLockStatus(doors=_FakeDoors(trunk=_FakeTrunk(closed=None, locked=None)))
+    )
+    assert TRUNK_DOOR_LOCK_ENTITY_DESCRIPTION.value_fn(vehicle) is None
+    assert TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION.value_fn(vehicle) is None
+
+
+def test_trunk_inverts_populated_values():
+    """Toyota reports closed/locked; HA DOOR and LOCK classes want the inverse."""
+    vehicle = _vehicle(
+        _FakeLockStatus(doors=_FakeDoors(trunk=_FakeTrunk(closed=True, locked=True)))
+    )
+    assert TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION.value_fn(vehicle) is False
+    assert TRUNK_DOOR_LOCK_ENTITY_DESCRIPTION.value_fn(vehicle) is False
+
+    vehicle = _vehicle(
+        _FakeLockStatus(doors=_FakeDoors(trunk=_FakeTrunk(closed=False, locked=False)))
+    )
+    assert TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION.value_fn(vehicle) is True
+    assert TRUNK_DOOR_LOCK_ENTITY_DESCRIPTION.value_fn(vehicle) is True
+
+
+def test_trunk_fields_are_independent():
+    """An open but still-unlocked-unknown trunk must not leak across fields."""
+    vehicle = _vehicle(
+        _FakeLockStatus(doors=_FakeDoors(trunk=_FakeTrunk(closed=False, locked=None)))
+    )
+    assert TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION.value_fn(vehicle) is True
+    assert TRUNK_DOOR_LOCK_ENTITY_DESCRIPTION.value_fn(vehicle) is None


### PR DESCRIPTION
Relates to #87. Answers the `TODO(CM000n): Find correct matching capabilities in _vehicle_info` that sits above the two trunk entries in `async_setup_entry`.

Please read the "What this deliberately does *not* do" section before merging — this improves #87 but does not deliver what the reporter literally asked for, so I have not added a closing keyword.

## The bug

`TRUNK_DOOR_LOCK_ENTITY_DESCRIPTION` and `TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION` are gated on `extended_capabilities.bonnet_status` — the **hood's** flag. The mismatch is wrong in both directions:

- A car that reports `bonnet_status` but has no trunk telemetry gets two trunk entities it should not have. This is the visible half of #87.
- A car that reports a trunk but *not* `bonnet_status` gets **no trunk entities at all**, even though the data is sitting in `lock_status.doors.trunk`. This half is silent, which is probably why it has gone unreported.

## Why there is no correct flag to swap in

I went looking for the flag the TODO is asking for, and I do not believe it exists. Checked against pytoyoda's `vehicle_guid.py` models, the trunk-adjacent fields are:

| Field | Model | What it describes |
|---|---|---|
| `trunk_lock_unlock_capable` | `_ExtendedCapabilitiesModel` | remote lock/unlock **command** |
| `power_tailgate_capable` | `_ExtendedCapabilitiesModel` | power tailgate **hardware/command** |
| `trunk_capable` | `_RemoteServiceCapabilitiesModel` | remote service **command** |
| `rear_hatch_rear_window` | `_ExtendedCapabilitiesModel` | rear hatch window, not the trunk lid |

Every one is a *command* capability. The status flags follow a different naming pattern entirely — `front_driver_door_open_status`, `rear_passenger_door_lock_status`, `bonnet_status` — and there is simply no `trunk_*_status` member. Gating a status sensor on a command capability would be a different wrong answer, not a right one: a car can report trunk state without supporting remote trunk lock/unlock.

There is also direct evidence in #87 that these flags are not trustworthy even for their own sensor. The reporter's car returns `hood: {closed: null, locked: null}` while `bonnet_status` was evidently True — otherwise the hood entity would never have been created to misreport in the first place. So even a perfectly-matched flag would not have prevented the original symptom.

## What this changes

The two trunk sensors are now created unconditionally. This is not a new posture for this file — `VEHICLE_HEALTH_ENTITY_DESCRIPTION`, immediately below, is already ungated for the same reason, with a comment saying so.

It is safe now in a way it would not have been a year ago, because of @nledenyi's `_inv_or_none` in d3c3e12: a field that never reports yields `None` and the entity reads **unknown**, not a false "open"/"unlocked". The original #87 symptom cannot recur through this path.

## Trade-off, stated plainly

Cars that never report a trunk gain two `unknown` entities they did not have before — specifically the subset where `bonnet_status` is False or absent.

In practice this is a small delta, because `bonnet_status` is True on most cars, and those cars already get these entities today. But it is a real change and I would rather name it than let it be discovered in review.

## What this deliberately does *not* do

#87's stated expectation was that the entities be **absent**:

> Hood: Door entity not present / Trunk: Door entity not present / Trunk: Lock entity not present

This PR does not do that, and moves in the opposite direction. I think entity-presence keyed on data-presence is the wrong mechanism here: `async_setup_entry` runs once, so a cold or failed first fetch would permanently suppress entities until a reload, and the entity set would then differ between restarts depending on what the API happened to return. Reporting "unknown" is the honest representation of "the car has not told us".

That is a judgement call about your integration, not mine, so I have used `Relates to` rather than `Fixes` and left #87 open. If you would rather have data-gated presence, say so and I will rework it — the hood would need the same treatment for consistency.

## Tests

`tests/test_binary_sensor_trunk.py` pins the null path for both entities, since they now appear on every car: cold cache, missing `doors`, missing `trunk`, the exact `{closed: null, locked: null}` shape from #87, correct inversion when populated, and independence of the two fields.

Note: I could not run the suite locally (no `homeassistant` in my environment), so I verified the expectations by replicating the two `value_fn` getattr chains standalone against the same fixtures — all seven cases pass. CI is the real check here.

## Noted, but not changed

`TRUNK_DOOR_OPEN_ENTITY_DESCRIPTION` carries `device_class=BinarySensorDeviceClass.WINDOW` while every other door sensor uses `DOOR` (visible in the #87 thread, where a reporter pasted `device_class: window` on their trunk entity). It looks like a copy-paste slip. I left it alone to keep this PR to one claim — happy to send a one-liner separately if you want it.
