### PR TITLE
fix(trips): recent-trips fetch without Vehicle.get_recent_trips()

### DIFF
--- a/custom_components/toyota/trips_manager.py
+++ b/custom_components/toyota/trips_manager.py
@@ -21,7 +21,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import timedelta
 from typing import TYPE_CHECKING
+
+from homeassistant.util import dt as dt_util
 
 from .refresh_strategy import RefreshTrigger
 from .trips_cache import TripsCacheStore
@@ -44,13 +47,29 @@ _LOGGER = logging.getLogger(__name__)
 # refill via ``max_recent_trips``.
 DELTA_FETCH_LIMIT = 2
 
+# How far back to look when asking Toyota for the most recent trips. The
+# endpoint is date-windowed, so a window is mandatory; 90 days is what
+# pytoyoda itself uses for ``Vehicle.get_last_trip()``.
+TRIPS_LOOKBACK_DAYS = 90
+
+
+def _shape_sort_key(shape: dict) -> float:
+    """Sortable epoch for a card-shaped trip; unknown timestamps sort last."""
+    ts = shape.get("start_ts")
+    if isinstance(ts, str):
+        ts = dt_util.parse_datetime(ts)
+    try:
+        return ts.timestamp()  # type: ignore[union-attr]
+    except (AttributeError, ValueError, OSError, OverflowError):
+        return 0.0
+
 
 class RecentTripsManager:
     """Per-config-entry orchestrator for the recent-trips sensor data path.
 
     Independent of the existing cycle's ``trip_history`` endpoint (which
     stays at limit=1, route=False for backward compatibility). This manager
-    issues separate ``Vehicle.get_recent_trips()`` calls when configured.
+    issues separate trip-history calls (see ``_fetch_trips``) when configured.
     """
 
     def __init__(
@@ -74,7 +93,7 @@ class RecentTripsManager:
         self._underfilled_vins: set[str] = set()
         # Per-VIN locks serialise cache mutation paths (cold-start seed,
         # delta-fetch, service refresh). Without them a coordinator stop tick
-        # racing a service/button call can issue duplicate get_recent_trips
+        # racing a service/button call can issue duplicate trip-history
         # calls and last-writer-wins on the cache + _followup_pending state.
         self._locks: dict[str, asyncio.Lock] = {}
 
@@ -264,7 +283,7 @@ class RecentTripsManager:
     ) -> list[dict] | None:
         """Fetch + transform. Returns None on fetch failure, list on success."""
         try:
-            trips = await vehicle.get_recent_trips(limit=limit, with_route=True)
+            trips = await self._fetch_trips(vehicle, limit)
         except Exception:
             _LOGGER.exception(
                 "Toyota recent-trips fetch failed for vin=...%s", vin[-6:]
@@ -279,7 +298,53 @@ class RecentTripsManager:
             shape = to_card_shape(raw, alias)
             if shape is not None:
                 out.append(shape)
+        # The delta/dedup path walks the list newest-first; don't rely on the
+        # endpoint's ordering for that invariant.
+        out.sort(key=_shape_sort_key, reverse=True)
         return out
+
+    async def _fetch_trips(self, vehicle: Vehicle, limit: int) -> list:
+        """Return up to ``limit`` most recent pytoyoda ``Trip`` objects.
+
+        pytoyoda 5.x has no recent-trips helper, and the public
+        ``Vehicle.get_trips()`` pages the whole window five trips per
+        request (with full routes attached that is a lot of calls against an
+        endpoint that rate-limits bursts). So we hit the same endpoint
+        ``Vehicle.get_last_trip()`` uses - once, asking for ``limit`` trips
+        with route data - and only fall back to the paginated public call if
+        that private path ever stops working.
+        """
+        getter = getattr(vehicle, "get_recent_trips", None)
+        if callable(getter):
+            # Fork / future pytoyoda that ships a first-class helper.
+            return list(await getter(limit=limit, with_route=True) or [])
+
+        to_date = dt_util.now().date()
+        from_date = to_date - timedelta(days=TRIPS_LOOKBACK_DAYS)
+        try:
+            from pytoyoda.models.trips import Trip  # noqa: PLC0415
+
+            resp = await vehicle._api.get_trips(  # noqa: SLF001
+                vehicle.vin,
+                from_date,
+                to_date,
+                route=True,
+                summary=False,
+                limit=limit,
+                offset=0,
+            )
+            payload = getattr(resp, "payload", None)
+            raw = list(getattr(payload, "trips", None) or [])
+            if raw:
+                return [Trip(t, vehicle._metric) for t in raw[:limit]]  # noqa: SLF001
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Toyota recent-trips direct endpoint call failed, "
+                "falling back to paginated get_trips",
+                exc_info=True,
+            )
+        trips = await vehicle.get_trips(from_date, to_date, full_route=True)
+        return list(trips or [])[:limit]
 
     async def _seed_cache(self, vehicle: Vehicle, vin: str, limit: int) -> bool:
         """Fetch + commit (set + save); True on success.


### PR DESCRIPTION
### Problem

`RecentTripsManager._fetch_shapes()` calls `vehicle.get_recent_trips(limit=..., with_route=True)`, but **that helper does not exist in pytoyoda 5.2.0** — the version this integration pins (`pytoyoda>=5.2.0,<6.0` in `manifest.json`).

Every recent-trips fetch therefore raises, roughly every 10 minutes:

```
AttributeError: 'Vehicle' object has no attribute 'get_recent_trips'
```

The cache never fills and `sensor.<vehicle>_recent_trips` stays empty. The public API surface in pytoyoda 5.x is `get_trips(from_date, to_date, full_route)`, `get_last_trip()` and `trip_history`.

### Why not just call `get_trips()`

`Vehicle.get_trips()` pages the whole date window **five trips per request**, with full routes attached, against an endpoint that rate-limits bursts (see the pytoyoda `update()` docstring). For a 90-day window that is dozens of heavy calls on every refresh.

### Fix

New `RecentTripsManager._fetch_trips(vehicle, limit)`:

1. if a future pytoyoda ever ships `get_recent_trips`, use it (forward-compatible, no behaviour change for such a version);
2. otherwise hit the **same endpoint `get_last_trip()` already uses** — `vehicle._api.get_trips(vin, from, to, route=True, summary=False, limit=limit, offset=0)` — **one** request returning the newest `limit` trips with route data;
3. on any failure there, fall back to the public paginated `vehicle.get_trips(..., full_route=True)`.

Window is `TRIPS_LOOKBACK_DAYS = 90`, matching what pytoyoda itself uses for `get_last_trip()`.

Also: `_fetch_shapes()` now sorts card shapes **newest-first** (`_shape_sort_key`, epoch of `start_ts`) instead of trusting endpoint ordering. The delta/dedup walk in `_delta_fetch()` and the prepend order in the cache both depend on that invariant.

### Note on private access

This keeps the module's existing coupling to pytoyoda internals — it already reads `Trip._trip` in `_raw_trip_dict`. The new `_api.get_trips` / `Trip(trip, metric)` use is guarded by try/except with a public-API fallback, so a pytoyoda 6 signature change degrades to the slow path instead of breaking. Worth re-checking when pytoyoda 6 lands.

### Verification

Running live on a Toyota C-HR 2022 Hybrid (HA 2026.x, pytoyoda 5.2.0):

- `ha core check` OK, HA restarted
- `toyota.refresh_recent_trips` with `limit: 5` → sensor state `5`
- trips returned newest-first (12:13 → 11:05 → 10:34 → 06:42 → 06:30)
- full routes present (`route_point_count` 8837 / 376 / 682 / 7118 / 226)
- no further `trips_manager` errors in the log

Regression introduced by #330.