### PR TITLE
Added button to call refresh_electric_realtime_status

### DIFF
--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -1054,8 +1054,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:  # noqa: C901
         device_ids: list[str] = [raw] if isinstance(raw, str) else list(raw)
         if not device_ids:
             _LOGGER.warning(
-                "toyota.refresh_electric_realtime_status called with no "
-                "device target"
+                "toyota.refresh_electric_realtime_status called with no device target"
             )
             return
         _LOGGER.info(
@@ -1087,8 +1086,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:  # noqa: C901
                     await vehicle.refresh_electric_realtime_status()
                 except Exception:
                     _LOGGER.exception(
-                        "toyota.refresh_electric_realtime_status failed for "
-                        "vin=...%s",
+                        "toyota.refresh_electric_realtime_status failed for vin=...%s",
                         vin[-6:],
                     )
             # Schedule a refresh so the electric/battery sensors pick up the

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -954,6 +954,7 @@ SERVICE_REFRESH_RECENT_TRIPS = "refresh_recent_trips"
 ATTR_LIMIT = "limit"
 SERVICE_GET_TRIP_ROUTE = "get_trip_route"
 ATTR_TRIP_ID = "trip_id"
+SERVICE_REFRESH_ELECTRIC_REALTIME_STATUS = "refresh_electric_realtime_status"
 
 
 def _resolve_devices_to_vins_per_entry(
@@ -988,7 +989,7 @@ def _resolve_devices_to_vins_per_entry(
     return per_entry_vins
 
 
-async def _async_register_services(hass: HomeAssistant) -> None:
+async def _async_register_services(hass: HomeAssistant) -> None:  # noqa: C901
     """Register the toyota.refresh_vehicle_status service exactly once.
 
     Service handlers resolve their target devices to VINs via the device
@@ -1039,6 +1040,65 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         DOMAIN,
         SERVICE_REFRESH_VEHICLE_STATUS,
         _handle_refresh_vehicle_status,
+    )
+
+    async def _handle_refresh_electric_realtime_status(call: ServiceCall) -> None:
+        """Force a fresh electric/EV realtime status read for the targeted vehicles.
+
+        Calls pytoyoda's Vehicle.refresh_electric_realtime_status(), which
+        wakes the vehicle to report fresh battery level and charging state.
+        Use sparingly - each call uses cellular airtime and, per pytoyoda's
+        own docs, drains a small amount of 12V battery if used too often.
+        """
+        raw = call.data.get("device_id") or []
+        device_ids: list[str] = [raw] if isinstance(raw, str) else list(raw)
+        if not device_ids:
+            _LOGGER.warning(
+                "toyota.refresh_electric_realtime_status called with no "
+                "device target"
+            )
+            return
+        _LOGGER.info(
+            "toyota.refresh_electric_realtime_status invoked for devices=%s",
+            device_ids,
+        )
+        per_entry_vins = _resolve_devices_to_vins_per_entry(hass, device_ids)
+        for entry_id, vins in per_entry_vins.items():
+            coord = hass.data[DOMAIN].get(entry_id)
+            if coord is None or coord.data is None:
+                continue
+            for vin in vins:
+                vehicle = next(
+                    (
+                        vd["data"]
+                        for vd in coord.data
+                        if vd.get("data") is not None and vd["data"].vin == vin
+                    ),
+                    None,
+                )
+                if vehicle is None:
+                    _LOGGER.warning(
+                        "toyota.refresh_electric_realtime_status: VIN ...%s "
+                        "not in coordinator data; skipping",
+                        vin[-6:],
+                    )
+                    continue
+                try:
+                    await vehicle.refresh_electric_realtime_status()
+                except Exception:
+                    _LOGGER.exception(
+                        "toyota.refresh_electric_realtime_status failed for "
+                        "vin=...%s",
+                        vin[-6:],
+                    )
+            # Schedule a refresh so the electric/battery sensors pick up the
+            # freshly-woken data on the next coordinator cycle.
+            hass.async_create_task(coord.async_request_refresh())
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REFRESH_ELECTRIC_REALTIME_STATUS,
+        _handle_refresh_electric_realtime_status,
     )
 
     await _async_register_trips_services(hass)

--- a/custom_components/toyota/button.py
+++ b/custom_components/toyota/button.py
@@ -82,9 +82,10 @@ async def async_setup_entry(
                 description=REFRESH_RECENT_TRIPS_BUTTON_DESCRIPTION,
             )
         )
-        if get_vehicle_capability(
-            vehicle, "econnect_vehicle_status_capable"
-        ) or vehicle.type == "electric":
+        if (
+            get_vehicle_capability(vehicle, "econnect_vehicle_status_capable")
+            or vehicle.type == "electric"
+        ):
             buttons.append(
                 ToyotaRefreshElectricRealtimeStatusButton(
                     coordinator=coordinator,

--- a/custom_components/toyota/button.py
+++ b/custom_components/toyota/button.py
@@ -17,6 +17,7 @@ from .const import (
     DOMAIN,
 )
 from .entity import ToyotaBaseEntity
+from .sensor import get_vehicle_capability
 
 # Default fetch size for the manual button when auto-fetch is off
 # (max_recent_trips=0). Picked as a sensible "show me the last few drives".
@@ -45,6 +46,13 @@ REFRESH_RECENT_TRIPS_BUTTON_DESCRIPTION = ButtonEntityDescription(
     icon="mdi:refresh-auto",
 )
 
+REFRESH_ELECTRIC_REALTIME_STATUS_BUTTON_DESCRIPTION = ButtonEntityDescription(
+    key="refresh_electric_realtime_status",
+    translation_key="refresh_electric_realtime_status",
+    name="Refresh electric realtime status",
+    icon="mdi:battery-sync",
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -57,6 +65,7 @@ async def async_setup_entry(
     ]
     buttons: list[ButtonEntity] = []
     for index in range(len(coordinator.data)):
+        vehicle = coordinator.data[index]["data"]
         buttons.append(
             ToyotaRefreshStatusButton(
                 coordinator=coordinator,
@@ -73,6 +82,17 @@ async def async_setup_entry(
                 description=REFRESH_RECENT_TRIPS_BUTTON_DESCRIPTION,
             )
         )
+        if get_vehicle_capability(
+            vehicle, "econnect_vehicle_status_capable"
+        ) or vehicle.type == "electric":
+            buttons.append(
+                ToyotaRefreshElectricRealtimeStatusButton(
+                    coordinator=coordinator,
+                    entry_id=entry.entry_id,
+                    vehicle_index=index,
+                    description=REFRESH_ELECTRIC_REALTIME_STATUS_BUTTON_DESCRIPTION,
+                )
+            )
     async_add_entities(buttons)
 
 
@@ -129,5 +149,32 @@ class ToyotaRefreshRecentTripsButton(ToyotaBaseEntity, ButtonEntity):
             DOMAIN,
             "refresh_recent_trips",
             {"device_id": [device.id], "limit": limit},
+            blocking=False,
+        )
+
+
+class ToyotaRefreshElectricRealtimeStatusButton(ToyotaBaseEntity, ButtonEntity):
+    """One-tap wrapper around toyota.refresh_electric_realtime_status.
+
+    Only added for vehicles that support the EV/electric status endpoint.
+    Wakes the vehicle to force a fresh battery/charging state read; use
+    sparingly as each call uses cellular airtime and a small amount of
+    12V battery.
+    """
+
+    async def async_press(self) -> None:
+        """Fire toyota.refresh_electric_realtime_status for this vehicle."""
+        from homeassistant.helpers import device_registry as dr  # noqa: PLC0415
+
+        device_reg = dr.async_get(self.hass)
+        device = device_reg.async_get_device(
+            identifiers={(DOMAIN, self.vehicle.vin or "")}
+        )
+        if device is None:
+            return
+        await self.hass.services.async_call(
+            DOMAIN,
+            "refresh_electric_realtime_status",
+            {"device_id": [device.id]},
             blocking=False,
         )

--- a/custom_components/toyota/services.yaml
+++ b/custom_components/toyota/services.yaml
@@ -61,6 +61,22 @@ refresh_recent_trips:
           step: 1
           mode: box
 
+refresh_electric_realtime_status:
+  name: Refresh electric realtime status
+  description: >
+    Wakes the vehicle to force a fresh read of the electric/EV realtime
+    status (battery level, charging state, range). Use sparingly - each
+    call uses cellular airtime and, per the underlying API, can drain a
+    small amount of 12V battery if called too often.
+  fields:
+    device_id:
+      name: Vehicle
+      description: The Toyota vehicle whose electric realtime status to refresh.
+      required: true
+      selector:
+        device:
+          integration: toyota
+
 get_trip_route:
   name: Get trip route
   description: >

--- a/custom_components/toyota/translations/en.json
+++ b/custom_components/toyota/translations/en.json
@@ -158,6 +158,9 @@
       },
       "refresh_recent_trips": {
         "name": "Refresh recent trips"
+      },
+      "refresh_electric_realtime_status": {
+        "name": "Refresh electric realtime status"
       }
     },
     "binary_sensor": {

--- a/custom_components/toyota/translations/nb.json
+++ b/custom_components/toyota/translations/nb.json
@@ -107,6 +107,17 @@
         "name": "Current year statistics"
       }
     },
+    "button": {
+      "refresh_vehicle_status": {
+        "name": "Oppdater bilens status"
+      },
+      "refresh_recent_trips": {
+        "name": "Oppdater Siste kjørte ruter"
+      },
+      "refresh_electric_realtime_status": {
+        "name": "Oppdater bilens batteri prosent"
+      }
+    },
     "binary_sensor": {
       "over_all_status": {
         "name": "Over all status"


### PR DESCRIPTION
I have added a button to call the `toyota.refresh_electric_realtime_status` to trigger a update from the car.

It has been working with my BZ4X for the last couple of days to update the soc during charging.
As I have limited experience with python, and less developing Homeassistant custom component, I have used some ai for the implementation, so give feedback.